### PR TITLE
Added codes that compute root nodes in ontologies

### DIFF
--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/hpo/HpoAnnotationLine.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/hpo/HpoAnnotationLine.java
@@ -1,6 +1,5 @@
 package org.monarchinitiative.phenol.io.obo.hpo;
 
-import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoDisease;
 import org.monarchinitiative.phenol.ontology.data.ImmutableTermId;
 import org.monarchinitiative.phenol.ontology.data.TermId;

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/owl/OwlImmutableOntologyLoader.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/owl/OwlImmutableOntologyLoader.java
@@ -126,13 +126,13 @@ public final class OwlImmutableOntologyLoader<T extends Term, R extends Relation
 
       Optional<String> subCurie = curieUtil.getCurie(subId);
       if (subCurie.isPresent() != true) {
-        LOGGER.error("No matching curie found for edge's subject: " + subId);
+        LOGGER.warn("No matching curie found for edge's subject: " + subId);
         continue;
       }
 
       Optional<String> objCurie = curieUtil.getCurie(objId);
       if (objCurie.isPresent() != true) {
-        LOGGER.error("No matching curie found for edge's object: " + objId);
+        LOGGER.warn("No matching curie found for edge's object: " + objId);
         continue;
       }
 

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/owl/OwlImmutableOntologyLoaderTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/owl/OwlImmutableOntologyLoaderTest.java
@@ -81,6 +81,11 @@ public class OwlImmutableOntologyLoaderTest {
     assertNotNull(gr2);
     assertEquals(gr1.getRelationshipType(), GenericRelationshipType.IS_A);
     assertEquals(gr2.getRelationshipType(), GenericRelationshipType.IS_A);
+
+    // 5. The example file contains multiple roots; thus we just put owl:Thing as the root.
+    TermId rootTermId = ontology.getRootTermId();
+    assertEquals(rootTermId.getPrefix().getValue(), "owl");
+    assertEquals(rootTermId.getId(), "Thing");
   }
 
   @Test
@@ -101,7 +106,7 @@ public class OwlImmutableOntologyLoaderTest {
             "SCTID:92100009",
             "UMLS:C0346190");
 
-    // Check whether the example GenericTerm instance properly read all xref entries.
+    // 1. Check whether the example GenericTerm instance properly read all xref entries.
     for (GenericTerm gt : ontology.getTerms()) {
       for (Dbxref xref : gt.getXrefs()) {
         Boolean containFlag = false;
@@ -111,5 +116,10 @@ public class OwlImmutableOntologyLoaderTest {
         if (!containFlag) fail("Xref " + xref.getName() + " is not available.");
       }
     }
+
+    // 2. This sample ontology file contains a single root labeled as MONDO:0000624.
+    TermId rootTermId = ontology.getRootTermId();
+    assertEquals(rootTermId.getPrefix().getValue(), "MONDO");
+    assertEquals(rootTermId.getId(), "0000624");
   }
 }

--- a/phenol-io/src/test/resources/mondo_module.owl
+++ b/phenol-io/src/test/resources/mondo_module.owl
@@ -17,16 +17,6 @@
      xmlns:dc="http://purl.org/dc/elements/1.1/">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/mondo-module.owl">
         <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/mondo/releases/2018-03-16/mondo.owl"/>
-        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/mondo/imports/ncbitaxon_import.owl"/>
-        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/mondo/imports/cl_import.owl"/>
-        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/mondo/imports/go_import.owl"/>
-        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/mondo/imports/uberon_import.owl"/>
-        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/mondo/imports/mf_import.owl"/>
-        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/mondo/imports/ro_import.owl"/>
-        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/mondo/imports/pato_import.owl"/>
-        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/mondo/imports/axioms.owl"/>
-        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/mondo/imports/chebi_import.owl"/>
-        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/mondo/imports/envo_import.owl"/>
         <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
         <foaf:homepage rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">obofoundry.org/ontology/mondo.html</foaf:homepage>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Includes Ontology(OntologyID(OntologyIRI(&lt;http://purl.obolibrary.org/obo/mondo/imports/equivalencies.owl&gt;) VersionIRI(&lt;null&gt;))) [Axioms: 142991 Logical Axioms: 61249]</rdfs:comment>
@@ -34,8 +24,6 @@
         <oboInOwl:hasOBOFormatVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1.2</oboInOwl:hasOBOFormatVersion>
         <terms:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A semi-automatically constructed ontology that merges in multiple disease resources to yield a coherent merged ontology.</terms:description>
     </owl:Ontology>
-
-    <!-- http://purl.obolibrary.org/obo/MONDO_0000645 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0000645">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/NCIT_C4517"/>
@@ -53,14 +41,6 @@
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MONDO_0000624"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MONDO_0015861"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MONDO_0021092"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0004026"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003889"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <obo1:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A non-metastasizing neoplasm that arises from the fallopian tube. Representative examples include papilloma, adenofibroma, and leiomyoma.</obo1:IAO_0000115>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOID:0060111</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ICD10:D28.2</oboInOwl:hasDbXref>


### PR DESCRIPTION
In order to cover [this issue](https://github.com/monarch-initiative/phenol/issues/70), I extended the current owl loader to compute root nodes while loading owl files. 
  - The codes first collect nodes that have incoming edges as well as marking nodes that have outgoing edges. Later the codes will remove the marked nodes from the nodes that have incoming edges. In the case where multiple root nodes are discovered or not discovered at all, the codes will assign `owl:Thing` as the root node. I also revised the testcase to reflect this chage.

  - Please note that the mondo.owl's root is not `MONDO:000001` but `owl:Thing`, so the  `ontology.getRootTermId()` will now literally return `owl:Thing` based on the hirarchy shown in [this page](http://www.ontobee.org/ontology/MONDO?iri=http://purl.obolibrary.org/obo/MONDO_0000001). 

  - It's possible that this may not what Peter wants, but maybe revising the method that computes common ancestors might be a better choice if we want to retrieve the term `MONDO:000001` as a common parent node. I will work on this issue soon. Thank you for your patience. 