### PR TITLE
Support InputStreams in OBO parsers

### DIFF
--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/PrecomputeScoresCommand.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/PrecomputeScoresCommand.java
@@ -17,6 +17,7 @@ import org.monarchinitiative.phenol.ontology.scoredist.ScoreSamplingOptions;
 import org.monarchinitiative.phenol.ontology.scoredist.SimilarityScoreSampling;
 import org.monarchinitiative.phenol.ontology.similarity.ResnikSimilarity;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.*;
 import java.util.Map.Entry;
@@ -86,9 +87,16 @@ public class PrecomputeScoresCommand {
 
   private void loadOntology() throws PhenolException {
     LOGGER.info("Loading ontology from OBO...");
-    HpOboParser hpOboParser = new HpOboParser(new File(options.getOboFile()));
-    HpoOntology ontology = hpOboParser.parse();
-    phenotypicAbnormalitySubOntology = ontology.getPhenotypicAbnormalitySubOntology();
+    HpOboParser hpOboParser;
+	try {
+		hpOboParser = new HpOboParser(new File(options.getOboFile()));
+	    HpoOntology ontology = hpOboParser.parse();
+	    phenotypicAbnormalitySubOntology = ontology.getPhenotypicAbnormalitySubOntology();
+	} catch (FileNotFoundException e) {
+		LOGGER.error(e.getMessage(), e);
+	    LOGGER.error("Problem reading from obo file.");
+	    return;
+	}
     LOGGER.info("Done loading ontology.");
 
     LOGGER.info("Loading gene-to-term link file...");

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/OboOntologyLoader.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/OboOntologyLoader.java
@@ -63,14 +63,10 @@ public final class OboOntologyLoader {
    * Construct an OWL loader that can load an OBO ontology.
    * @param file Path to the OBO file
    */
-  public OboOntologyLoader(File file) {
-    try {
-      this.obo = new FileInputStream(file);
-      curieUtil = new CurieUtil(CurieMapGenerator.generate());
-      this.factory = new Owl2OboTermFactory();
-    } catch (FileNotFoundException e) {
-      throw new RuntimeException("Cannot find file " + file.getName(), e);
-    }
+  public OboOntologyLoader(File file) throws FileNotFoundException {
+    this.obo = new FileInputStream(file);
+    curieUtil = new CurieUtil(CurieMapGenerator.generate());
+    this.factory = new Owl2OboTermFactory();
   }
   
   public OboOntologyLoader(InputStream obo) {

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/OboOntologyLoader.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/OboOntologyLoader.java
@@ -63,20 +63,20 @@ public final class OboOntologyLoader {
    * Construct an OWL loader that can load an OBO ontology.
    * @param file Path to the OBO file
    */
-	public OboOntologyLoader(File file) {
-	  try {
-		this.obo = new FileInputStream(file);
-		curieUtil = new CurieUtil(CurieMapGenerator.generate());
-		this.factory = new Owl2OboTermFactory();
-	  } catch (FileNotFoundException e) {
-		throw new RuntimeException("Cannot find file " + file.getName(), e);
-	  }
+  public OboOntologyLoader(File file) {
+    try {
+      this.obo = new FileInputStream(file);
+      curieUtil = new CurieUtil(CurieMapGenerator.generate());
+      this.factory = new Owl2OboTermFactory();
+    } catch (FileNotFoundException e) {
+      throw new RuntimeException("Cannot find file " + file.getName(), e);
+    }
   }
   
   public OboOntologyLoader(InputStream obo) {
-	this.obo = obo;
-	curieUtil = new CurieUtil(CurieMapGenerator.generate());
-	this.factory = new Owl2OboTermFactory();
+    this.obo = obo;
+    curieUtil = new CurieUtil(CurieMapGenerator.generate());
+    this.factory = new Owl2OboTermFactory();
   }
 
   public Ontology load() throws PhenolException {

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/go/GoOboParser.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/go/GoOboParser.java
@@ -24,11 +24,11 @@ public class GoOboParser {
 
   public GoOboParser(File oboFile, boolean debug) {
     try {
-  	  this.obo = new FileInputStream(oboFile);
-	  this.debug = debug;
-	} catch (FileNotFoundException e) {
-	  throw new RuntimeException("Cannot find file " + oboFile.getName(), e);
-	}
+      this.obo = new FileInputStream(oboFile);
+      this.debug = debug;
+    } catch (FileNotFoundException e) {
+      throw new RuntimeException("Cannot find file " + oboFile.getName(), e);
+    }
   }
   
   public GoOboParser(File oboFile) {
@@ -36,12 +36,12 @@ public class GoOboParser {
   }
   
   public GoOboParser(InputStream obo, boolean debug) {
-	this.obo = obo;
-	this.debug = debug;
+    this.obo = obo;
+    this.debug = debug;
   }
   
   public GoOboParser(InputStream obo) {
-	this(obo,false);
+    this(obo,false);
   }
 
   public GoOntology parse() throws PhenolException {

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/go/GoOboParser.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/go/GoOboParser.java
@@ -22,16 +22,12 @@ public class GoOboParser {
 
   private final boolean debug;
 
-  public GoOboParser(File oboFile, boolean debug) {
-    try {
-      this.obo = new FileInputStream(oboFile);
-      this.debug = debug;
-    } catch (FileNotFoundException e) {
-      throw new RuntimeException("Cannot find file " + oboFile.getName(), e);
-    }
+  public GoOboParser(File oboFile, boolean debug) throws FileNotFoundException {
+    this.obo = new FileInputStream(oboFile);
+    this.debug = debug;
   }
   
-  public GoOboParser(File oboFile) {
+  public GoOboParser(File oboFile) throws FileNotFoundException {
     this(oboFile,false);
   }
   

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/go/GoOboParser.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/go/GoOboParser.java
@@ -12,26 +12,40 @@ import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
 import java.io.File;
-import java.util.Map;
-import java.util.Optional;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 
 public class GoOboParser {
 
-  private final File oboFile;
+  private final InputStream obo;
 
   private final boolean debug;
 
   public GoOboParser(File oboFile, boolean debug) {
-    this.oboFile = oboFile;
-    this.debug = debug;
+    try {
+  	  this.obo = new FileInputStream(oboFile);
+	  this.debug = debug;
+	} catch (FileNotFoundException e) {
+	  throw new RuntimeException("Cannot find file " + oboFile.getName(), e);
+	}
   }
+  
   public GoOboParser(File oboFile) {
     this(oboFile,false);
   }
-
+  
+  public GoOboParser(InputStream obo, boolean debug) {
+	this.obo = obo;
+	this.debug = debug;
+  }
+  
+  public GoOboParser(InputStream obo) {
+	this(obo,false);
+  }
 
   public GoOntology parse() throws PhenolException {
-    final OboOntologyLoader loader = new OboOntologyLoader(oboFile);
+    final OboOntologyLoader loader = new OboOntologyLoader(obo);
     Ontology ontology = loader.load();
     if (debug) {
       System.err.println(String.format("Parsed a total of %d MP terms",ontology.countAllTerms()));

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/hpo/HpOboParser.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/hpo/HpOboParser.java
@@ -24,11 +24,11 @@ public class HpOboParser {
 
   public HpOboParser(File oboFile, boolean debug) {
 	try {
-  	  this.obo = new FileInputStream(oboFile);
-	  this.debug = debug;
-	} catch (FileNotFoundException e) {
-	  throw new RuntimeException("Cannot find file " + oboFile.getName(), e);
-	}
+      this.obo = new FileInputStream(oboFile);
+      this.debug = debug;
+    } catch (FileNotFoundException e) {
+      throw new RuntimeException("Cannot find file " + oboFile.getName(), e);
+    }
   }
   
   public HpOboParser(File oboFile) throws PhenolException {
@@ -36,12 +36,12 @@ public class HpOboParser {
   }
   
   public HpOboParser(InputStream obo, boolean debug) {
-	this.obo = obo;
-	this.debug = debug;
+    this.obo = obo;
+    this.debug = debug;
   }
   
   public HpOboParser(InputStream obo) {
-	this(obo,false);
+    this(obo,false);
   }
 
   public HpoOntology parse() throws PhenolException {

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/hpo/HpOboParser.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/hpo/HpOboParser.java
@@ -2,6 +2,12 @@ package org.monarchinitiative.phenol.io.obo.hpo;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+
 import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
 import org.monarchinitiative.phenol.io.obo.OboOntologyLoader;
@@ -10,27 +16,38 @@ import org.monarchinitiative.phenol.ontology.data.Relationship;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
-import java.io.File;
-
 public class HpOboParser {
 
-  private final File oboFile;
+  private final InputStream obo;
 
   private final boolean debug;
 
   public HpOboParser(File oboFile, boolean debug) {
-    this.oboFile = oboFile;
-    this.debug = debug;
+	try {
+  	  this.obo = new FileInputStream(oboFile);
+	  this.debug = debug;
+	} catch (FileNotFoundException e) {
+	  throw new RuntimeException("Cannot find file " + oboFile.getName(), e);
+	}
   }
-  public HpOboParser(File oboFile) {
+  
+  public HpOboParser(File oboFile) throws PhenolException {
     this(oboFile,false);
   }
-
+  
+  public HpOboParser(InputStream obo, boolean debug) {
+	this.obo = obo;
+	this.debug = debug;
+  }
+  
+  public HpOboParser(InputStream obo) {
+	this(obo,false);
+  }
 
   public HpoOntology parse() throws PhenolException {
     Ontology ontology;
 
-    final OboOntologyLoader loader = new OboOntologyLoader(oboFile);
+    final OboOntologyLoader loader = new OboOntologyLoader(obo);
     ontology = loader.load();
     if (debug) {
       System.err.println(String.format("Parsed a total of %d HP terms",ontology.countAllTerms()));

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/hpo/HpOboParser.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/hpo/HpOboParser.java
@@ -22,16 +22,12 @@ public class HpOboParser {
 
   private final boolean debug;
 
-  public HpOboParser(File oboFile, boolean debug) {
-	try {
-      this.obo = new FileInputStream(oboFile);
-      this.debug = debug;
-    } catch (FileNotFoundException e) {
-      throw new RuntimeException("Cannot find file " + oboFile.getName(), e);
-    }
+  public HpOboParser(File oboFile, boolean debug) throws FileNotFoundException {
+    this.obo = new FileInputStream(oboFile);
+    this.debug = debug;
   }
   
-  public HpOboParser(File oboFile) throws PhenolException {
+  public HpOboParser(File oboFile) throws FileNotFoundException {
     this(oboFile,false);
   }
   

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/mpo/MpOboParser.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/mpo/MpOboParser.java
@@ -6,27 +6,40 @@ import org.monarchinitiative.phenol.io.obo.OboOntologyLoader;
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 
 import java.io.File;
-import java.util.Optional;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 
 public class MpOboParser {
 
-  private final File oboFile;
+  private final InputStream obo;
 
   private final boolean debug;
 
   public MpOboParser(File oboFile, boolean debug) {
-    this.oboFile = oboFile;
-    this.debug = debug;
+    try {
+  	  this.obo = new FileInputStream(oboFile);
+	  this.debug = debug;
+	} catch (FileNotFoundException e) {
+	  throw new RuntimeException("Cannot find file " + oboFile.getName(), e);
+	}
   }
-
-
+  
   public MpOboParser(File oboFile) {
     this(oboFile,false);
   }
-
+  
+  public MpOboParser(InputStream obo, boolean debug) {
+	this.obo = obo;
+	this.debug = debug;
+  }
+  
+  public MpOboParser(InputStream obo) {
+	this(obo,false);
+  }
 
   public Ontology parse() throws PhenolException {
-    final OboOntologyLoader loader = new OboOntologyLoader(oboFile);
+    final OboOntologyLoader loader = new OboOntologyLoader(obo);
     Ontology ontology = loader.load();
     if (debug) {
         System.err.println(String.format("Parsed a total of %d MP terms",ontology.countAllTerms()));

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/mpo/MpOboParser.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/mpo/MpOboParser.java
@@ -16,16 +16,12 @@ public class MpOboParser {
 
   private final boolean debug;
 
-  public MpOboParser(File oboFile, boolean debug) {
-    try {
+  public MpOboParser(File oboFile, boolean debug) throws FileNotFoundException {
       this.obo = new FileInputStream(oboFile);
       this.debug = debug;
-    } catch (FileNotFoundException e) {
-      throw new RuntimeException("Cannot find file " + oboFile.getName(), e);
-    }
   }
   
-  public MpOboParser(File oboFile) {
+  public MpOboParser(File oboFile) throws FileNotFoundException {
     this(oboFile,false);
   }
   

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/mpo/MpOboParser.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/mpo/MpOboParser.java
@@ -18,11 +18,11 @@ public class MpOboParser {
 
   public MpOboParser(File oboFile, boolean debug) {
     try {
-  	  this.obo = new FileInputStream(oboFile);
-	  this.debug = debug;
-	} catch (FileNotFoundException e) {
-	  throw new RuntimeException("Cannot find file " + oboFile.getName(), e);
-	}
+      this.obo = new FileInputStream(oboFile);
+      this.debug = debug;
+    } catch (FileNotFoundException e) {
+      throw new RuntimeException("Cannot find file " + oboFile.getName(), e);
+    }
   }
   
   public MpOboParser(File oboFile) {
@@ -30,12 +30,12 @@ public class MpOboParser {
   }
   
   public MpOboParser(InputStream obo, boolean debug) {
-	this.obo = obo;
-	this.debug = debug;
+    this.obo = obo;
+    this.debug = debug;
   }
   
   public MpOboParser(InputStream obo) {
-	this(obo,false);
+    this(obo,false);
   }
 
   public Ontology parse() throws PhenolException {

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/assoc/HpoAssociationParserTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/assoc/HpoAssociationParserTest.java
@@ -1,52 +1,44 @@
 package org.monarchinitiative.phenol.io.assoc;
 
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.Gene;
 import org.monarchinitiative.phenol.formats.hpo.DiseaseToGeneAssociation;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
 import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
-import org.monarchinitiative.phenol.io.utils.ResourceUtils;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertTrue;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 
 public class HpoAssociationParserTest {
-  private static HpoAssociationParser parser;
+  private HpoAssociationParser parser;
 
-  @ClassRule
-  public static TemporaryFolder tmpFolder = new TemporaryFolder();
-
-  @BeforeClass
-  public static void init() throws IOException, PhenolException {
+  @Before
+  public void init() throws IOException, PhenolException {
     System.setProperty("user.timezone", "UTC"); // Somehow setting in pom.xml does not work :(
 
-    File mim2gene = tmpFolder.newFile("mim2gene_medgen");
-    ResourceUtils.copyResourceToFile("/mim2gene_medgen.excerpt", mim2gene);
+	ClassLoader classLoader = this.getClass().getClassLoader();
 
-    File geneInfo = tmpFolder.newFile("Homo_sapiens.gene_info.gz");
-    ResourceUtils.copyResourceToFile("/Homo_sapiens.gene_info.excerpt.gz", geneInfo);
-
-    File hpoHeadFile = tmpFolder.newFile("hp_head.obo");
-    ResourceUtils.copyResourceToFile("/hp_head.obo", hpoHeadFile);
-    final HpOboParser oboParser = new HpOboParser(hpoHeadFile, true);
+    URL mim2GeneUrl = classLoader.getResource("mim2gene_medgen.excerpt");
+    URL geneInfoUrl = classLoader.getResource("Homo_sapiens.gene_info.excerpt.gz");
+ 
+    final HpOboParser oboParser = new HpOboParser(classLoader.getResourceAsStream("hp_head.obo"), true);
     final HpoOntology ontology = oboParser.parse();
 
-    parser = new HpoAssociationParser(geneInfo.getAbsolutePath(), mim2gene.getAbsolutePath(), ontology);
+    parser = new HpoAssociationParser(geneInfoUrl.getPath(), mim2GeneUrl.getPath(), ontology);
     parser.parse();
   }
 

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/go/GoOboParserTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/go/GoOboParserTest.java
@@ -1,31 +1,17 @@
 package org.monarchinitiative.phenol.io.obo.go;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.StringEndsWith.endsWith;
-import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.Optional;
 
 import org.jgrapht.graph.DefaultDirectedGraph;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
 import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.go.GoOntology;
 import org.monarchinitiative.phenol.graph.IdLabeledEdge;
-import org.monarchinitiative.phenol.io.utils.ResourceUtils;
-import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
-
-import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.ImmutableSortedSet;
 
 /**
  * Testcases that verify whether obo-formatted Go ontology is properly parsed and loaded.
@@ -34,16 +20,13 @@ import com.google.common.collect.ImmutableSortedSet;
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  */
 public class GoOboParserTest {
-  @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
-  private File goHeadFile;
 
   private GoOntology ontology;
 
   @Before
   public void setUp() throws IOException, PhenolException {
-    goHeadFile = tmpFolder.newFile("go_head.obo");
-    ResourceUtils.copyResourceToFile("/go_head.obo", goHeadFile);
-    GoOboParser parser = new GoOboParser(goHeadFile);
+	ClassLoader classLoader = this.getClass().getClassLoader();
+    GoOboParser parser = new GoOboParser(classLoader.getResourceAsStream("go_head.obo"));
     this.ontology = parser.parse();
   }
 

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/go/GoOboParserTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/go/GoOboParserTest.java
@@ -25,7 +25,7 @@ public class GoOboParserTest {
 
   @Before
   public void setUp() throws IOException, PhenolException {
-	ClassLoader classLoader = this.getClass().getClassLoader();
+    ClassLoader classLoader = this.getClass().getClassLoader();
     GoOboParser parser = new GoOboParser(classLoader.getResourceAsStream("go_head.obo"));
     this.ontology = parser.parse();
   }

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/hpo/HpOboParserTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/hpo/HpOboParserTest.java
@@ -22,8 +22,8 @@ public class HpOboParserTest {
 
   @Before
   public void setUp() throws IOException, PhenolException {
-	ClassLoader classLoader = this.getClass().getClassLoader();
-	final HpOboParser parser = new HpOboParser(classLoader.getResourceAsStream("hp_head.obo"));
+    ClassLoader classLoader = this.getClass().getClassLoader();
+    final HpOboParser parser = new HpOboParser(classLoader.getResourceAsStream("hp_head.obo"));
     ontology = parser.parse();
   }
 

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/hpo/HpOboParserTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/hpo/HpOboParserTest.java
@@ -1,35 +1,29 @@
 package org.monarchinitiative.phenol.io.obo.hpo;
 
-import org.jgrapht.graph.DefaultDirectedGraph;
-import org.junit.*;
-import org.junit.rules.TemporaryFolder;
-import org.monarchinitiative.phenol.base.PhenolException;
-import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.graph.IdLabeledEdge;
-import org.monarchinitiative.phenol.io.utils.ResourceUtils;
-import org.monarchinitiative.phenol.ontology.data.Term;
-import org.monarchinitiative.phenol.ontology.data.TermId;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Map;
-
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
 
+import java.io.IOException;
+import java.util.Map;
+
+import org.jgrapht.graph.DefaultDirectedGraph;
+import org.junit.Before;
+import org.junit.Test;
+import org.monarchinitiative.phenol.base.PhenolException;
+import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
+import org.monarchinitiative.phenol.graph.IdLabeledEdge;
+import org.monarchinitiative.phenol.ontology.data.Term;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+
 public class HpOboParserTest {
 
-  @ClassRule
-  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+  private HpoOntology ontology;
 
-  private static HpoOntology ontology;
-
-  @BeforeClass
-  public static void setUp() throws IOException, PhenolException {
-    File hpoHeadFile = tmpFolder.newFile("hp_head.obo");
-    ResourceUtils.copyResourceToFile("/hp_head.obo", hpoHeadFile);
-    final HpOboParser parser = new HpOboParser(hpoHeadFile, true);
+  @Before
+  public void setUp() throws IOException, PhenolException {
+	ClassLoader classLoader = this.getClass().getClassLoader();
+	final HpOboParser parser = new HpOboParser(classLoader.getResourceAsStream("hp_head.obo"));
     ontology = parser.parse();
   }
 

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/mpo/MpoOboParserTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/mpo/MpoOboParserTest.java
@@ -35,7 +35,7 @@ public class MpoOboParserTest {
 
   @Before
   public void setUp() throws IOException, PhenolException {
-	ClassLoader classLoader = this.getClass().getClassLoader();
+    ClassLoader classLoader = this.getClass().getClassLoader();
     final MpOboParser parser = new MpOboParser(classLoader.getResourceAsStream("mp_head.obo"));
     this.ontology = parser.parse();
   }

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/mpo/MpoOboParserTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/mpo/MpoOboParserTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -14,18 +13,13 @@ import java.util.stream.Collectors;
 
 import org.jgrapht.graph.DefaultDirectedGraph;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
 import org.monarchinitiative.phenol.base.PhenolException;
+import org.monarchinitiative.phenol.graph.IdLabeledEdge;
+import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.monarchinitiative.phenol.ontology.data.SimpleXref;
 import org.monarchinitiative.phenol.ontology.data.Term;
-
-import org.monarchinitiative.phenol.graph.IdLabeledEdge;
-import org.monarchinitiative.phenol.io.utils.ResourceUtils;
 import org.monarchinitiative.phenol.ontology.data.TermId;
-import org.monarchinitiative.phenol.ontology.data.Ontology;
 
 
 
@@ -37,17 +31,12 @@ import org.monarchinitiative.phenol.ontology.data.Ontology;
  */
 public class MpoOboParserTest {
 
-  @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
-
-  private File mpoHeadFile;
-
   private Ontology ontology;
 
   @Before
   public void setUp() throws IOException, PhenolException {
-    mpoHeadFile = tmpFolder.newFile("mp_head.obo");
-    ResourceUtils.copyResourceToFile("/mp_head.obo", mpoHeadFile);
-    MpOboParser parser = new MpOboParser(mpoHeadFile);
+	ClassLoader classLoader = this.getClass().getClassLoader();
+    final MpOboParser parser = new MpOboParser(classLoader.getResourceAsStream("mp_head.obo"));
     this.ontology = parser.parse();
   }
 
@@ -109,8 +98,6 @@ public class MpoOboParserTest {
    */
   @Test
   public void testGetAllFourTerms() throws PhenolException {
-    MpOboParser parser = new MpOboParser(mpoHeadFile);
-    Ontology ontology = parser.parse();
     Collection<Term> terms = ontology.getTerms();
     Set<TermId> tids = terms.stream().map(Term::getId).collect(Collectors.toSet());
     assertTrue(tids.contains(TermId.constructWithPrefix("MP:0000001")));


### PR DESCRIPTION
These changes would allow OBO parsers to accept an InputStream in their constructors. Constructors with Files are still supported. The parser tests will work without modification, but the changes here demonstrate a cleaner implementation when streams are used, eliminating the need for a TemporaryFolder for copying resources.