### PR TITLE
Fixing go parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,10 +34,10 @@ buildNumber.properties
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 .idea/
-/phenol-io/phenol-io.iml
-/phenol-cli/phenol-cli.iml
 *.checkstyle
-/phenol-core/phenol-core.iml
+*.iml
 phenol-cli/target/
 phenol-core/target/
 phenol-io/target/
+phenol-core/src/test/java/com/
+phenol-io/src/test/resources/catalog-v001.xml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,15 @@
 Changelog
 =========
 ------
+v1.2.3
+------
+- Adding parsing of relations other than IS_A for Gene Ontology
+
+------
 v1.2.2
 ------
 - Adding MP annotation parser for MGI_GenePheno.rst and MGI_Pheno_Sex.rst
+
 
 ------
 v1.1.1

--- a/phenol-cli/pom.xml
+++ b/phenol-cli/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.monarchinitiative.phenol</groupId>
     <artifactId>phenol</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
 
   <properties>

--- a/phenol-core/pom.xml
+++ b/phenol-core/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.monarchinitiative.phenol</groupId>
     <artifactId>phenol</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
 
   <properties>

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/algo/OntologyAlgorithm.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/algo/OntologyAlgorithm.java
@@ -165,14 +165,18 @@ public class OntologyAlgorithm {
     if (includeOriginalTerm) anccset.add(childTermId);
     Map<TermId,Term> tmap=ontology.getTermMap();
     for (IdLabeledEdge edge : ontology.getGraph().outgoingEdgesOf(childTermId)) {
-
-
+      int edgeId = edge.getId();
+      Relationship rel = ontology.getRelationMap().get(edgeId);
+      if (rel==null) {
+        System.err.println("Could not retrieve relation for id="+
+          edgeId+" [child term=" + ontology.getTermMap().get(childTermId).getName()+"]");
+        continue;
+      }
+      RelationshipType reltyp = rel.getRelationshipType();
+      if (! reltyp.propagates()) {
+        continue; // this is a relationship that does not follow the annotation-propagation rule (aka true path rule)
+      }
       TermId destId = (TermId) edge.getTarget();
-
-      System.err.println(String.format("%s <- %s <- %s",
-        tmap.get(childTermId.getIdWithPrefix()).getName(),
-        ontology.getRelationMap().get(edge.getId()).getRelationshipType(),
-        tmap.get(destId.getIdWithPrefix()).getName()));
       anccset.add(destId);
     }
     return anccset.build();

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/algo/OntologyAlgorithm.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/algo/OntologyAlgorithm.java
@@ -163,7 +163,6 @@ public class OntologyAlgorithm {
       boolean includeOriginalTerm) {
     ImmutableSet.Builder<TermId> anccset = new ImmutableSet.Builder<>();
     if (includeOriginalTerm) anccset.add(childTermId);
-    Map<TermId,Term> tmap=ontology.getTermMap();
     for (IdLabeledEdge edge : ontology.getGraph().outgoingEdgesOf(childTermId)) {
       int edgeId = edge.getId();
       Relationship rel = ontology.getRelationMap().get(edgeId);

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/algo/OntologyAlgorithm.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/algo/OntologyAlgorithm.java
@@ -163,8 +163,16 @@ public class OntologyAlgorithm {
       boolean includeOriginalTerm) {
     ImmutableSet.Builder<TermId> anccset = new ImmutableSet.Builder<>();
     if (includeOriginalTerm) anccset.add(childTermId);
+    Map<TermId,Term> tmap=ontology.getTermMap();
     for (IdLabeledEdge edge : ontology.getGraph().outgoingEdgesOf(childTermId)) {
+
+
       TermId destId = (TermId) edge.getTarget();
+
+      System.err.println(String.format("%s <- %s <- %s",
+        tmap.get(childTermId.getIdWithPrefix()).getName(),
+        ontology.getRelationMap().get(edge.getId()).getRelationshipType(),
+        tmap.get(destId.getIdWithPrefix()).getName()));
       anccset.add(destId);
     }
     return anccset.build();

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/RelationshipType.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/RelationshipType.java
@@ -1,5 +1,7 @@
 package org.monarchinitiative.phenol.ontology.data;
 
+import org.monarchinitiative.phenol.base.PhenolException;
+
 /**
  * Enumeration for describing relation qualifiers (forked from GoRelationQualifer in Ontolib).
  * A class that encapsulates the edge type in the ontology graph.
@@ -16,15 +18,76 @@ public enum RelationshipType {
   /** "DISJOINT_FROM" relation. */
   DISJOINT_FROM("disjoint_from"),
   PART_OF("part_of"),
+  HAS_PART("has_part"),
   REGULATES("regulates"),
   NEGATIVELY_REGULATES("negatively_regulates"),
   POSITIVELY_REGULATES("positively_regulates"),
+  OCCURS_IN("occurs_in"),
+  HAPPENS_DURING("happens_during"),
+  ENDS_DURING("ends_during"),
+  SUBPROPERTY_OF("subpropertyOf"),
+  INVERSE_OF("inverseOf"),
   /** Unknown, used for any other relation. */
   UNKNOWN("unknown");
 
   private final String relationshipName;
-  private RelationshipType(String name){
+  RelationshipType(String name){
     this.relationshipName=name;
+  }
+
+  public String getRelationshipName(){ return this.relationshipName; }
+
+
+  static public RelationshipType fromString(String reltype) throws PhenolException  {
+    switch (reltype) {
+      case "is_a":
+        return IS_A;
+      case "http://purl.obolibrary.org/obo/BFO_0000050":
+      case "part of":
+      case "part_of":
+        return PART_OF;
+      case "http://purl.obolibrary.org/obo/BFO_0000051":
+      case "has part":
+        return HAS_PART;
+      case "http://purl.obolibrary.org/obo/RO_0002211":
+      case "regulates":
+        return REGULATES;
+      case "http://purl.obolibrary.org/obo/RO_0002212":
+      case "negatively regulates":
+        return NEGATIVELY_REGULATES;
+      case "http://purl.obolibrary.org/obo/RO_0002213":
+      case "positively regulates":
+        return POSITIVELY_REGULATES;
+      case "http://purl.obolibrary.org/obo/BFO_0000066":
+      case "occurs in":
+        return OCCURS_IN;
+      case "http://purl.obolibrary.org/obo/RO_0002092":
+      case "happens during":
+        return HAPPENS_DURING;
+      case "http://purl.obolibrary.org/obo/RO_0002093":
+      case "ends during":
+        return ENDS_DURING;
+      case "subPropertyOf":
+        return SUBPROPERTY_OF;
+      case "inverseOf":
+        return INVERSE_OF;
+      default:
+        throw new PhenolException("Did not recognize RelationshipType: " + reltype);
+    }
+  }
+
+  /**
+   * This function returns true if a RelationshipType obeys the annotation propagation rule (aka true-path rule)
+   * @return true for IS_A and PART_OF, otherwise false
+   */
+  public boolean propagates() {
+    switch (this) {
+      case IS_A:
+      case PART_OF:
+        return true;
+      default:
+        return false;
+    }
   }
 
 

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/algo/OntologyAlgorithmRelationshipTest.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/algo/OntologyAlgorithmRelationshipTest.java
@@ -46,6 +46,25 @@ public class OntologyAlgorithmRelationshipTest {
   private TermId t3_1;
   private TermId t3_2;
 
+  /** Convenience method for making fake terms */
+  private Term makeTerm(TermId tid, String name, String definition ) {
+    return new Term(
+      tid,
+      new ArrayList<>(),
+      name,
+      definition,
+      ImmutableList.of(),
+      null,
+      new ArrayList<>(),
+      new ArrayList<>(),
+      false,
+      null,
+      null,
+      new ArrayList<>());
+  }
+
+
+
   @Before
   public void setUp() {
     metaInfo = ImmutableSortedMap.of();
@@ -75,185 +94,53 @@ public class OntologyAlgorithmRelationshipTest {
     GraphUtil.addEdgeToGraph(graph, t2_2, t2, 8);
     GraphUtil.addEdgeToGraph(graph, t3_1, t3, 9);
     GraphUtil.addEdgeToGraph(graph, t3_2, t3, 10);
+    // need to add corresponding relationships!
+    ImmutableMap.Builder<Integer, Relationship> relationMapBuilder = ImmutableMap.builder();
+    int i=1;
+    relationMapBuilder.put(i, new Relationship(root, t1, i, RelationshipType.IS_A));
+    i++;
+    relationMapBuilder.put(i, new Relationship(root, t2, i, RelationshipType.IS_A));
+    i++;
+    relationMapBuilder.put(i, new Relationship(root, t3, i, RelationshipType.IS_A));
+    i++;
+    relationMapBuilder.put(i, new Relationship(t1, t1_1, i, RelationshipType.IS_A));
+    i++;
+    relationMapBuilder.put(i, new Relationship(t1, t1_2, i, RelationshipType.IS_A));
+    i++;
+    relationMapBuilder.put(i, new Relationship(t1_1, t1_1_1, i, RelationshipType.IS_A));
+    i++;
+    relationMapBuilder.put(i, new Relationship(t1_1, t1_1_2, i, RelationshipType.IS_A));
+    i++;
+    relationMapBuilder.put(i, new Relationship(t2, t2_1, i, RelationshipType.IS_A));
+    i++;
+    relationMapBuilder.put(i, new Relationship(t2, t2_2, i, RelationshipType.IS_A));
+    i++;
+    relationMapBuilder.put(i, new Relationship(t3, t3_1, i, RelationshipType.IS_A));
+    i++;
+    relationMapBuilder.put(i, new Relationship(t3, t3_2, i, RelationshipType.IS_A));
+    relationMap = relationMapBuilder.build();
 
     rootTermId = root;
 
     ImmutableMap.Builder<TermId, Term> termMapBuilder = ImmutableMap.builder();
-    termMapBuilder.put(
-        t1,
-        new Term(
-            t1,
-            new ArrayList<>(),
-            "term1",
-            "some definition 1",
-          ImmutableList.of(),
-            null,
-            new ArrayList<>(),
-            new ArrayList<>(),
-            false,
-            null,
-            null,
-            new ArrayList<>()));
-    termMapBuilder.put(
-        t2,
-        new Term(
-            t2,
-            new ArrayList<>(),
-            "term2",
-            "some definition 2",
-          ImmutableList.of(),
-            null,
-            new ArrayList<>(),
-            new ArrayList<>(),
-            false,
-            null,
-            null,
-            new ArrayList<>()));
-    termMapBuilder.put(
-        t3,
-        new Term(
-            t3,
-            new ArrayList<>(),
-            "term3",
-            "some definition 3",
-          ImmutableList.of(),
-            null,
-            new ArrayList<>(),
-            new ArrayList<>(),
-            false,
-            null,
-            null,
-            new ArrayList<>()));
-    termMapBuilder.put(
-        t1_1,
-        new Term(
-            t1_1,
-            new ArrayList<>(),
-            "term1_1",
-            "some definition 4",
-          ImmutableList.of(),
-            null,
-            new ArrayList<>(),
-            new ArrayList<>(),
-            false,
-            null,
-            null,
-            new ArrayList<>()));
-    termMapBuilder.put(
-        t1_2,
-        new Term(
-            t1_2,
-            new ArrayList<>(),
-            "term1_2",
-            "some definition 5",
-          ImmutableList.of(),
-            null,
-            new ArrayList<>(),
-            new ArrayList<>(),
-            false,
-            null,
-            null,
-            new ArrayList<>()));
-
-    termMapBuilder.put(
-        t1_1_1,
-        new Term(
-            t1_1_1,
-            new ArrayList<>(),
-            "term1_1_1",
-            "some definition 1_1_1",
-          ImmutableList.of(),
-            null,
-            new ArrayList<>(),
-            new ArrayList<>(),
-            false,
-            null,
-            null,
-            new ArrayList<>()));
-    termMapBuilder.put(
-        t1_1_2,
-        new Term(
-            t1_1_2,
-            new ArrayList<>(),
-            "term1_1_2",
-            "some definition 1_1_2",
-          ImmutableList.of(),
-            null,
-            new ArrayList<>(),
-            new ArrayList<>(),
-            false,
-            null,
-            null,
-            new ArrayList<>()));
-    termMapBuilder.put(
-        t2_1,
-        new Term(
-            t2_1,
-            new ArrayList<>(),
-            "term2_1",
-            "some definition 2_1",
-          ImmutableList.of(),
-            null,
-            new ArrayList<>(),
-            new ArrayList<>(),
-            false,
-            null,
-            null,
-            new ArrayList<>()));
-    termMapBuilder.put(
-        t2_2,
-        new Term(
-            t2_2,
-            new ArrayList<>(),
-            "term2_2",
-            "some definition 2_2",
-          ImmutableList.of(),
-            null,
-            new ArrayList<>(),
-            new ArrayList<>(),
-            false,
-            null,
-            null,
-            new ArrayList<>()));
-    termMapBuilder.put(
-        t3_1,
-        new Term(
-            t3_1,
-            new ArrayList<>(),
-            "term3_1",
-            "some definition 3_1",
-          ImmutableList.of(),
-            null,
-            new ArrayList<>(),
-            new ArrayList<>(),
-            false,
-            null,
-            null,
-            new ArrayList<>()));
-    termMapBuilder.put(
-        t3_2,
-        new Term(
-            t3_2,
-            new ArrayList<>(),
-            "term3_2",
-            "some definition 3_2",
-          ImmutableList.of(),
-            null,
-            new ArrayList<>(),
-            new ArrayList<>(),
-            false,
-            null,
-            null,
-            new ArrayList<>()));
+    termMapBuilder.put(root,makeTerm(rootTermId,"root","root definition"));
+    termMapBuilder.put(t1, makeTerm(t1,"term1","some definition 1"));
+    termMapBuilder.put(t2, makeTerm(t2,"term2","some definition 2"));
+    termMapBuilder.put(t3, makeTerm(t3,"term3","some definition 3"));
+    termMapBuilder.put(t1_1, makeTerm(t1_1,"term1_1","some definition 1_1"));
+    termMapBuilder.put(t1_2, makeTerm(t1_2,"term1_2","some definition 1_2"));
+    termMapBuilder.put(t1_1_1, makeTerm(t1_1_1,"term1_1_1","some definition 1_1_1"));
+    termMapBuilder.put(t1_1_2, makeTerm(t1_1_2,"term1_1_2","some definition 1_1_2"));
+    termMapBuilder.put(t2_1, makeTerm(t2_1,"term2_1","some definition 2_1"));
+    termMapBuilder.put(t2_2, makeTerm(t2_2,"term2_2","some definition 2_2"));
+    termMapBuilder.put(t3_1, makeTerm(t3_1,"term3_1","some definition 3_1"));
+    termMapBuilder.put(t3_2, makeTerm(t3_2,"term3_2","some definition 3_2"));
 
     termMap = termMapBuilder.build();
 
     obsoleteTermMap = ImmutableMap.of();
 
-    ImmutableMap.Builder<Integer, Relationship> relationMapBuilder = ImmutableMap.builder();
-        relationMapBuilder.put(1, new Relationship(t1, t2, 1, RelationshipType.IS_A));
-        relationMapBuilder.put(2, new Relationship(t1, t3, 2, RelationshipType.IS_A));
-    relationMap = relationMapBuilder.build();
+
 
     ontology =
         new ImmutableOntology(

--- a/phenol-io/pom.xml
+++ b/phenol-io/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.monarchinitiative.phenol</groupId>
     <artifactId>phenol</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
 
   <properties>

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/OboOntologyLoader.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/OboOntologyLoader.java
@@ -4,14 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.SortedMap;
+import java.util.*;
 
 import com.google.common.collect.*;
 import org.geneontology.obographs.model.*;
@@ -46,16 +39,16 @@ public final class OboOntologyLoader {
   private final CurieUtil curieUtil;
   private final InputStream obo;
   /** Term ids of non-obsolete Terms. */
-  private Collection<TermId> nonDepreTermIdNodes = Sets.newHashSet();
+  private final Collection<TermId> nonDepreTermIdNodes = Sets.newHashSet();
   /** Term ids of obsolete Terms. */
-  private Collection<TermId> depreTermIdNodes = Sets.newHashSet();
+  private final Collection<TermId> depreTermIdNodes = Sets.newHashSet();
 
 
   /** Key: a TermId; value: corresponding Term object. */
-  private SortedMap<TermId, Term> terms = Maps.newTreeMap();
+  private final SortedMap<TermId, Term> terms = Maps.newTreeMap();
   //private Collection<TermId> termIdNodes = Sets.newHashSet();
   /** The relations are numbered incrementally--this is the key, and the value is the corresponding relation.*/
-  private Map<Integer, Relationship> relationMap = Maps.newHashMap();
+  private final Map<Integer, Relationship> relationMap = Maps.newHashMap();
   /** Factory object that adds OBO-typical data to each term. */
   private final OwlOntologyEntryFactory factory;
 
@@ -77,7 +70,6 @@ public final class OboOntologyLoader {
 
   public Ontology load() throws PhenolException {
     Map<TermId,TermId> old2newTermIdMap = new HashMap<>();
-
     // We first load ontologies expressed in owl using Obographs's FromOwl class.
     OWLOntologyManager m = OWLManager.createOWLOntologyManager();
     OWLOntology ontology;
@@ -147,10 +139,10 @@ public final class OboOntologyLoader {
     Set<TermId> removeMarkSet = Sets.newHashSet();
 
 
+
     for (Edge edge : gEdges) {
       String subId = edge.getSub();
       String objId = edge.getObj();
-
       Optional<String> subCurie = curieUtil.getCurie(subId);
       if (! subCurie.isPresent() ) {
         LOGGER.warn("No matching curie found for edge's subject: " + subId);
@@ -179,12 +171,15 @@ public final class OboOntologyLoader {
       IdLabeledEdge e = new IdLabeledEdge();
       e.setId(edgeId);
       phenolGraph.addEdge(subTermId, objTermId, e);
-
-      Relationship ctr = factory.constructRelationship(subTermId, objTermId, edgeId);
+      RelationshipType reltype = RelationshipType.fromString(edge.getPred());
+      Relationship ctr = factory.constructRelationship(subTermId, objTermId, edgeId, reltype);
       relationMap.put(edgeId, ctr);
 
       edgeId += 1;
     }
+
+
+
 
     rootCandSet.removeAll(removeMarkSet);
     CompatibilityChecker.check(phenolGraph.vertexSet(), phenolGraph.edgeSet());
@@ -207,10 +202,8 @@ public final class OboOntologyLoader {
     // If there are multiple candidate roots, we will just put owl:Thing as the root one.
     TermId rootId;
     if (rootCandSet.isEmpty()) {
-      rootId = TermId.constructWithPrefix("owl:Thing");
       throw new PhenolException("No root candidate found.");
-
-    } if (rootCandSet.size() > 1 ) {
+    } else if (rootCandSet.size() > 1 ) {
       TermPrefix prefix;
       Optional<TermId> firstId = rootCandSet.stream().findFirst();
       // getPrefix should always work actually, but if we cannot find a term for some reason, use Owl as the prefix
@@ -219,6 +212,7 @@ public final class OboOntologyLoader {
       rootId = new TermId(prefix,"0000000");
       Term rootTerm = new Term();
       rootTerm.setId(rootId);
+      rootTerm.setName("artificial root term");
       phenolGraph.addVertex(rootId);
       nonDepreTermIdNodes.add(rootId);
       terms.put(rootId, rootTerm);
@@ -228,14 +222,15 @@ public final class OboOntologyLoader {
         e.setId(edgeId);
         edgeId++;
         phenolGraph.addEdge(childOfNewRootTermId, rootId, e);
-        Relationship ctr = factory.constructRelationship(childOfNewRootTermId, rootId, edgeId);
+        //Note-for the "artificial root term, we use the IS_A relation
+        Relationship ctr = factory.constructRelationship(childOfNewRootTermId, rootId, edgeId, RelationshipType.IS_A);
         relationMap.put(edgeId, ctr);
+        System.err.println("Putting rel for new root from term " + childOfNewRootTermId.getIdWithPrefix());
       }
     } else { // if we get here, there is exactly one root candidate
       List<TermId> rootCandList = new ArrayList<>(rootCandSet);
       rootId = rootCandList.get(0);
     }
-
 
     return  new ImmutableOntology(
       ImmutableSortedMap.copyOf(metaInfo),

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/OboOntologyLoader.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/OboOntologyLoader.java
@@ -114,6 +114,7 @@ public final class OboOntologyLoader {
       String nodeId = node.getId();
       Optional<String> nodeCurie = curieUtil.getCurie(nodeId);
       if (! nodeCurie.isPresent() ) continue;
+
       TermId termId = TermId.constructWithPrefix(nodeCurie.get());
       Term term = factory.constructTerm(node, termId);
       if (term.isObsolete()) {
@@ -174,12 +175,8 @@ public final class OboOntologyLoader {
       RelationshipType reltype = RelationshipType.fromString(edge.getPred());
       Relationship ctr = factory.constructRelationship(subTermId, objTermId, edgeId, reltype);
       relationMap.put(edgeId, ctr);
-
       edgeId += 1;
     }
-
-
-
 
     rootCandSet.removeAll(removeMarkSet);
     CompatibilityChecker.check(phenolGraph.vertexSet(), phenolGraph.edgeSet());
@@ -220,17 +217,18 @@ public final class OboOntologyLoader {
       for (TermId childOfNewRootTermId : rootCandSet) {
         IdLabeledEdge e = new IdLabeledEdge();
         e.setId(edgeId);
-        edgeId++;
         phenolGraph.addEdge(childOfNewRootTermId, rootId, e);
         //Note-for the "artificial root term, we use the IS_A relation
         Relationship ctr = factory.constructRelationship(childOfNewRootTermId, rootId, edgeId, RelationshipType.IS_A);
         relationMap.put(edgeId, ctr);
-        System.err.println("Putting rel for new root from term " + childOfNewRootTermId.getIdWithPrefix());
+        edgeId++;
       }
     } else { // if we get here, there is exactly one root candidate
       List<TermId> rootCandList = new ArrayList<>(rootCandSet);
       rootId = rootCandList.get(0);
     }
+
+
 
     return  new ImmutableOntology(
       ImmutableSortedMap.copyOf(metaInfo),

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/OboOntologyLoader.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/OboOntologyLoader.java
@@ -52,6 +52,9 @@ public final class OboOntologyLoader {
   /** Factory object that adds OBO-typical data to each term. */
   private final OwlOntologyEntryFactory factory;
 
+  private final TermPrefix BFO_PREFIX=new TermPrefix("BFO");
+  private final TermPrefix RO_PREFIX=new TermPrefix("RO");
+
   /**
    * Construct an OWL loader that can load an OBO ontology.
    * @param file Path to the OBO file
@@ -116,6 +119,10 @@ public final class OboOntologyLoader {
       if (! nodeCurie.isPresent() ) continue;
 
       TermId termId = TermId.constructWithPrefix(nodeCurie.get());
+      if (termId.getPrefix().equals(BFO_PREFIX) | termId.getPrefix().equals(RO_PREFIX)){
+        continue;
+      }
+
       Term term = factory.constructTerm(node, termId);
       if (term.isObsolete()) {
         depreTermIdNodes.add(termId);
@@ -160,6 +167,10 @@ public final class OboOntologyLoader {
       String objCurieStr = objCurie.get();
       TermId subTermId = TermId.constructWithPrefix(subCurieStr);
       TermId objTermId = TermId.constructWithPrefix(objCurieStr);
+      // Note that GO has some Terms/Relations with RO and BFO that we want to skip
+      if (subTermId.getPrefix().equals(BFO_PREFIX) || subTermId.getPrefix().equals(RO_PREFIX)) {
+        continue; // for GO, these relations have RO or BFO in both subject and object, no need to check both
+      }
 
       // For each edge and connected nodes,
       // we add candidate obj nodes in rootCandSet, i.e. nodes that have incoming edges.

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/go/GoOboParser.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/go/GoOboParser.java
@@ -26,16 +26,20 @@ public class GoOboParser {
     this.obo = new FileInputStream(oboFile);
     this.debug = debug;
   }
-  
+
   public GoOboParser(File oboFile) throws FileNotFoundException {
     this(oboFile,false);
   }
-  
+
   public GoOboParser(InputStream obo, boolean debug) {
     this.obo = obo;
     this.debug = debug;
   }
-  
+
+  public GoOboParser(String path) throws FileNotFoundException {
+    this(new File(path),false);
+  }
+
   public GoOboParser(InputStream obo) {
     this(obo,false);
   }

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/hpo/HpoDiseaseAnnotationParser.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obo/hpo/HpoDiseaseAnnotationParser.java
@@ -68,7 +68,7 @@ public class HpoDiseaseAnnotationParser {
     // First stage of parsing is to get the lines parsed and sorted according to disease.
     Map<TermId, List<HpoAnnotationLine>> disease2AnnotLineMap = new HashMap<>();
     Multimap<TermId, TermId> termToDisease = ArrayListMultimap.create();
-    ImmutableList.Builder errorbuilder=new ImmutableList.Builder();
+    ImmutableList.Builder<String> errorbuilder=new ImmutableList.Builder<>();
 
     try {
       BufferedReader br = new BufferedReader(new FileReader(this.annotationFilePath));

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/owl/Owl2OboTermFactory.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/owl/Owl2OboTermFactory.java
@@ -85,7 +85,7 @@ public class Owl2OboTermFactory
 
     // 6. obsolete; the obsolete/deprecated field in Meta is somehow not accessible,
     // so we use Java reflection to pull the value of that field.
-    Boolean isObsolete = false;
+    boolean isObsolete = false;
     try {
       Field f = Meta.class.getDeclaredField("deprecated");
       f.setAccessible(true);
@@ -117,7 +117,7 @@ public class Owl2OboTermFactory
 
   // It seems that only actual relation used across ontologies is "IS_A" one for now.
   @Override
-  public Relationship constructRelationship(TermId source, TermId dest, int id) {
-    return new Relationship(source, dest, id, RelationshipType.IS_A);
+  public Relationship constructRelationship(TermId source, TermId dest, int id,  RelationshipType reltype) {
+    return new Relationship(source, dest, id, reltype);
   }
 }

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/owl/OwlOntologyEntryFactory.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/owl/OwlOntologyEntryFactory.java
@@ -4,6 +4,7 @@ import org.geneontology.obographs.model.Node;
 
 
 import org.monarchinitiative.phenol.ontology.data.Relationship;
+import org.monarchinitiative.phenol.ontology.data.RelationshipType;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -16,5 +17,5 @@ import org.monarchinitiative.phenol.ontology.data.TermId;
 public interface OwlOntologyEntryFactory {
   Term constructTerm(Node node, TermId termId);
 
-  Relationship constructRelationship(TermId source, TermId dest, int id);
+  Relationship constructRelationship(TermId source, TermId dest, int id, RelationshipType reltype);
 }

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/go/GoOboParserTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/go/GoOboParserTest.java
@@ -1,13 +1,12 @@
 package org.monarchinitiative.phenol.io.obo.go;
 
 import static org.junit.Assert.assertEquals;
-import static org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm.getAncestorTerms;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Map;
-import java.util.Set;
 
 import org.jgrapht.graph.DefaultDirectedGraph;
 import org.junit.Before;
@@ -76,8 +75,9 @@ public class GoOboParserTest {
     GoOboParser parser = new GoOboParser(localpath);
     GoOntology gontology=parser.parse();
     Map<TermId,Term> termmap =  gontology.getTermMap();
+    assertNotNull(gontology);
     for (TermId tid : termmap.keySet()) {
-      String name = termmap.get(tid).getName();
+     // String name = termmap.get(tid).getName();
       tid=termmap.get(tid).getId();
       if (tid.getPrefix().equals(RO_PREFIX)) {
         System.err.println("FOUND " + tid.getPrefix());

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/go/GoOboParserTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/go/GoOboParserTest.java
@@ -20,9 +20,7 @@ import org.monarchinitiative.phenol.formats.go.GoOntology;
 import org.monarchinitiative.phenol.graph.IdLabeledEdge;
 
 import org.monarchinitiative.phenol.io.utils.ResourceUtils;
-import org.monarchinitiative.phenol.ontology.data.Ontology;
-import org.monarchinitiative.phenol.ontology.data.Term;
-import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.monarchinitiative.phenol.ontology.data.*;
 
 
 /**
@@ -67,19 +65,32 @@ public class GoOboParserTest {
     assertEquals(expected,tid);
   }
 
-
+  /**
+   * For local testing with the full Gene Ontology file. This does not need to run in a normal build
+   * @throws FileNotFoundException
+   * @throws PhenolException
+   */
   @Test @Ignore public void testReal() throws FileNotFoundException, PhenolException {
     String localpath="/home/robinp/data/go/go.obo";
+    TermPrefix RO_PREFIX=new TermPrefix("RO");
     GoOboParser parser = new GoOboParser(localpath);
     GoOntology gontology=parser.parse();
     Map<TermId,Term> termmap =  gontology.getTermMap();
     for (TermId tid : termmap.keySet()) {
       String name = termmap.get(tid).getName();
       tid=termmap.get(tid).getId();
-      System.out.println("Retrieving ancestors for " + name +"[" + tid.getIdWithPrefix() +"]");
-      Set<TermId> ancs = getAncestorTerms(gontology,tid,true);
-      System.out.println(String.format("%s: ancestors-n=%s",tid,ancs.size()));
-      break;
+      if (tid.getPrefix().equals(RO_PREFIX)) {
+        System.err.println("FOUND " + tid.getPrefix());
+      }
+//      System.out.println("Retrieving ancestors for " + name +"[" + tid.getIdWithPrefix() +"]");
+//      Set<TermId> ancs = getAncestorTerms(gontology,tid,true);
+//      System.out.println(String.format("%s: ancestors-n=%s",tid,ancs.size()));
+    }
+    Map<Integer, Relationship> relmap = ontology.getRelationMap();
+    for (Relationship r : relmap.values()) {
+      if (r.getSource().getPrefix().equals(RO_PREFIX)){
+        System.err.println("FOUND2 " + r);
+      }
     }
   }
 

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/go/GoOboParserTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/go/GoOboParserTest.java
@@ -1,9 +1,13 @@
 package org.monarchinitiative.phenol.io.obo.go;
 
 import static org.junit.Assert.assertEquals;
+import static org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm.getAncestorTerms;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
 
 import org.jgrapht.graph.DefaultDirectedGraph;
 import org.junit.Before;
@@ -11,10 +15,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.monarchinitiative.phenol.base.PhenolException;
+import org.monarchinitiative.phenol.formats.go.GoOntology;
 import org.monarchinitiative.phenol.graph.IdLabeledEdge;
 
 import org.monarchinitiative.phenol.io.utils.ResourceUtils;
 import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
 
@@ -58,6 +64,21 @@ public class GoOboParserTest {
     TermId tid = ontology.getRootTermId();
     TermId expected = TermId.constructWithPrefix("GO:0000000");
     assertEquals(expected,tid);
+  }
+
+
+  @Test public void testReal() throws FileNotFoundException, PhenolException {
+    String localpath="/home/peter/data/mgi/go.obo";
+    GoOboParser parser = new GoOboParser(localpath);
+    GoOntology gontology=parser.parse();
+    Map<TermId,Term> termmap =  gontology.getTermMap();
+    for (TermId tid : termmap.keySet()) {
+      String name = termmap.get(tid).getName();
+      tid=termmap.get(tid).getId();
+      System.out.println("Retrieving ancestors for " + name +"[" + tid.getIdWithPrefix() +"]");
+      Set<TermId> ancs = getAncestorTerms(gontology,tid,true);
+      System.out.println(String.format("%s: ancestors-n=%s",tid,ancs.size()));
+    }
   }
 
 

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/go/GoOboParserTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/go/GoOboParserTest.java
@@ -11,6 +11,7 @@ import java.util.Set;
 
 import org.jgrapht.graph.DefaultDirectedGraph;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -67,7 +68,7 @@ public class GoOboParserTest {
   }
 
 
-  @Test public void testReal() throws FileNotFoundException, PhenolException {
+  @Test @Ignore public void testReal() throws FileNotFoundException, PhenolException {
     String localpath="/home/robinp/data/go/go.obo";
     GoOboParser parser = new GoOboParser(localpath);
     GoOntology gontology=parser.parse();
@@ -75,9 +76,10 @@ public class GoOboParserTest {
     for (TermId tid : termmap.keySet()) {
       String name = termmap.get(tid).getName();
       tid=termmap.get(tid).getId();
-//      System.out.println("Retrieving ancestors for " + name +"[" + tid.getIdWithPrefix() +"]");
-//      Set<TermId> ancs = getAncestorTerms(gontology,tid,true);
-//      System.out.println(String.format("%s: ancestors-n=%s",tid,ancs.size()));
+      System.out.println("Retrieving ancestors for " + name +"[" + tid.getIdWithPrefix() +"]");
+      Set<TermId> ancs = getAncestorTerms(gontology,tid,true);
+      System.out.println(String.format("%s: ancestors-n=%s",tid,ancs.size()));
+      break;
     }
   }
 

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/go/GoOboParserTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obo/go/GoOboParserTest.java
@@ -68,16 +68,16 @@ public class GoOboParserTest {
 
 
   @Test public void testReal() throws FileNotFoundException, PhenolException {
-    String localpath="/home/peter/data/mgi/go.obo";
+    String localpath="/home/robinp/data/go/go.obo";
     GoOboParser parser = new GoOboParser(localpath);
     GoOntology gontology=parser.parse();
     Map<TermId,Term> termmap =  gontology.getTermMap();
     for (TermId tid : termmap.keySet()) {
       String name = termmap.get(tid).getName();
       tid=termmap.get(tid).getId();
-      System.out.println("Retrieving ancestors for " + name +"[" + tid.getIdWithPrefix() +"]");
-      Set<TermId> ancs = getAncestorTerms(gontology,tid,true);
-      System.out.println(String.format("%s: ancestors-n=%s",tid,ancs.size()));
+//      System.out.println("Retrieving ancestors for " + name +"[" + tid.getIdWithPrefix() +"]");
+//      Set<TermId> ancs = getAncestorTerms(gontology,tid,true);
+//      System.out.println(String.format("%s: ancestors-n=%s",tid,ancs.size()));
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.monarchinitiative.phenol</groupId>
   <artifactId>phenol</artifactId>
   <packaging>pom</packaging>
-  <version>1.2.2</version>
+  <version>1.2.3</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
 


### PR DESCRIPTION
This fixes the issue that the original OBO loader assumed that all relations are IS_A