### PR TITLE
added ECTO curie to curie_map.yaml

### DIFF
--- a/phenol-io/src/main/resources/curie_map.yaml
+++ b/phenol-io/src/main/resources/curie_map.yaml
@@ -38,6 +38,7 @@
 'DECIPHER' : 'http://purl.obolibrary.org/obo/DECIPHER_'  # DECIPHER: Deciphering Developmental Disease
 'DOID': 'http://purl.obolibrary.org/obo/DOID_'  # DOID: Human Disease Ontology  [y]
 'ECO': 'http://purl.obolibrary.org/obo/ECO_'  # ECO: Evidence Code Ontology [y]
+'ECTO': 'http://purl.obolibrary.org/obo/ECTO_' # ECTO: Environmental Exposure Ontology [y]
 'EFO' : 'http://www.ebi.ac.uk/efo/EFO_'  # EFO: Experimental Factor Ontology (all kinds of stuff) [y]
 'ENVO' : 'http://purl.obolibrary.org/obo/ENVO_'  # ENVO: Environment Ontology
 'EOM' : 'http://purl.obolibrary.org/obo/EOM_'  # elements of morphology phentoypes

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderTest.java
@@ -110,13 +110,14 @@ public class OntologyLoaderTest {
     Path ectoPath = Paths.get("src/test/resources/ecto.obo");
 
     // ECTO isn't mapped in the default Curie mappings, so we need to add it here (the PURL isn't correct)
-    CurieUtil curieUtil = CurieUtilBuilder.withDefaultsAnd(ImmutableMap.of("ECTO", "http://purl.obolibrary.org/obo/ECTO_"));
-    assertTrue(curieUtil.getCurieMap().containsKey("ECTO"));
+    //CurieUtil curieUtil = CurieUtilBuilder.withDefaultsAnd(ImmutableMap.of("ECTO", "http://purl.obolibrary.org/obo/ECTO_"));
+    //assertTrue(curieUtil.getCurieMap().containsKey("ECTO"));
 
     // ECTO also contains a bunch of unknown relationships so we're going to simplify this graph by only
     // loading ECTO nodes (this ignores the true root term XCO:0000000) and other nodes from CHEBI,
     // BFO and UBERON among others.
-    Ontology ecto = OntologyLoader.loadOntology(ectoPath.toFile(), curieUtil, "ECTO");
+    //Ontology ecto = OntologyLoader.loadOntology(ectoPath.toFile(), curieUtil, "ECTO");
+    Ontology ecto = OntologyLoader.loadOntology(ectoPath.toFile(), "ECTO");
 
     ecto.getRelationMap()
       .values()
@@ -136,8 +137,9 @@ public class OntologyLoaderTest {
     Path ectoPath = Paths.get("src/test/resources/ecto.obo");
 
     // ECTO isn't mapped in the default Curie mappings, so we need to add it here
-    CurieUtil curieUtil = CurieUtilBuilder.withDefaultsAnd(ImmutableMap.of("ECTO", "http://http://purl.obolibrary.org/obo/ECTO_"));
-    Ontology permissiveOntology = OntologyLoader.loadOntology(ectoPath.toFile(), curieUtil);
+    //CurieUtil curieUtil = CurieUtilBuilder.withDefaultsAnd(ImmutableMap.of("ECTO", "http://http://purl.obolibrary.org/obo/ECTO_"));
+    //Ontology permissiveOntology = OntologyLoader.loadOntology(ectoPath.toFile(), curieUtil);
+    Ontology permissiveOntology = OntologyLoader.loadOntology(ectoPath.toFile());
 
     assertEquals(TermId.of("owl:Thing"), permissiveOntology.getRootTermId());
     assertEquals(8343, permissiveOntology.countNonObsoleteTerms());


### PR DESCRIPTION
Instead of doing this, 
// ECTO isn't mapped in the default Curie mappings, so we need to add it here (the PURL isn't correct)
CurieUtil curieUtil = CurieUtilBuilder.withDefaultsAnd(ImmutableMap.of("ECTO", http://purl.obolibrary.org/obo/ECTO_"));

Can we just add it for simplicity?