### PR TITLE
fix so p=1 when similarity score equals the lower bound

### DIFF
--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/scoredist/ObjectScoreDistribution.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/scoredist/ObjectScoreDistribution.java
@@ -57,7 +57,7 @@ public final class ObjectScoreDistribution implements Serializable {
   public double estimatePValue(double score) {
     Entry<Double, Double> previous = null;
     for (Entry<Double, Double> entry : cumulativeFrequencies.entrySet()) {
-      if (previous == null && score < entry.getKey()) {
+      if (previous == null && score <= entry.getKey()) {
         return 1.0; // smaller than all
       }
       if (previous != null && previous.getKey() <= score && score < entry.getKey()) {

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/scoredist/ObjectScoreDistributionTest.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/scoredist/ObjectScoreDistributionTest.java
@@ -26,6 +26,7 @@ public class ObjectScoreDistributionTest {
   @Test
   public void testEstimatePValue() {
     assertEquals(1.0, objDist.estimatePValue(0.0), 0.01);
+    assertEquals(1.0, objDist.estimatePValue(0.1), 0.01);
     assertEquals(0.82, objDist.estimatePValue(0.2), 0.01);
     assertEquals(0.82, objDist.estimatePValue(0.4), 0.01);
     assertEquals(0.42, objDist.estimatePValue(0.6), 0.01);


### PR DESCRIPTION
If score distributions has range [0,5], p(x=0) should be 1. Currently, it estimates a value based on x = 0 and next x. Current implementation is fine except when score distribution has a single x value.