### PR TITLE
make mtc generic

### DIFF
--- a/phenol-analysis/src/main/java/org/monarchinitiative/phenol/stats/BenjaminiHochberg.java
+++ b/phenol-analysis/src/main/java/org/monarchinitiative/phenol/stats/BenjaminiHochberg.java
@@ -23,7 +23,7 @@ import java.util.List;
 public class BenjaminiHochberg<T> implements MultipleTestingCorrection<T>
 {
   @Override
-  public void adjustPvals(List<Item2PValue<T>> pvals) {
+  public void adjustPvals(List<? extends Item2PValue<T>> pvals) {
     Collections.sort(pvals);
     int N=pvals.size();
     for (int r=0;r<N;r++) {

--- a/phenol-analysis/src/main/java/org/monarchinitiative/phenol/stats/BenjaminiYekutieli.java
+++ b/phenol-analysis/src/main/java/org/monarchinitiative/phenol/stats/BenjaminiYekutieli.java
@@ -6,7 +6,7 @@ import java.util.List;
 public class BenjaminiYekutieli<T> implements MultipleTestingCorrection<T> {
 
   @Override
-  public void adjustPvals(List<Item2PValue<T>> pvals) {
+  public void adjustPvals(List<? extends Item2PValue<T>> pvals) {
     Collections.sort(pvals);
     int N = pvals.size();
     double h = 0.0;

--- a/phenol-analysis/src/main/java/org/monarchinitiative/phenol/stats/Bonferroni.java
+++ b/phenol-analysis/src/main/java/org/monarchinitiative/phenol/stats/Bonferroni.java
@@ -20,7 +20,7 @@ public class Bonferroni<T> implements MultipleTestingCorrection<T>
 	private static final String NAME = "Bonferroni";
 
   @Override
-  public void adjustPvals(List<Item2PValue<T>> pvals) {
+  public void adjustPvals(List<? extends Item2PValue<T>> pvals) {
     int N=pvals.size();
     for (Item2PValue<T> item : pvals) {
       double p_raw= item.getRawPValue();

--- a/phenol-analysis/src/main/java/org/monarchinitiative/phenol/stats/BonferroniHolm.java
+++ b/phenol-analysis/src/main/java/org/monarchinitiative/phenol/stats/BonferroniHolm.java
@@ -16,7 +16,7 @@ public class BonferroniHolm<T> implements MultipleTestingCorrection<T> {
   private static final String NAME = "Bonferroni-Holm";
 
   @Override
-  public void adjustPvals(List<Item2PValue<T>> pvals) {
+  public void adjustPvals(List<? extends Item2PValue<T>> pvals) {
     Collections.sort(pvals);
     int N=pvals.size();
     for (int r=0;r<N;r++) {

--- a/phenol-analysis/src/main/java/org/monarchinitiative/phenol/stats/MultipleTestingCorrection.java
+++ b/phenol-analysis/src/main/java/org/monarchinitiative/phenol/stats/MultipleTestingCorrection.java
@@ -17,7 +17,7 @@ public interface MultipleTestingCorrection<T>
 	 *
 	 * @param pvals an object implementing the p value 	calculation.
 	 */
-  void adjustPvals(List<Item2PValue<T>> pvals);
+  void adjustPvals(List<? extends Item2PValue<T>> pvals);
 
 
 	/**
@@ -35,7 +35,7 @@ public interface MultipleTestingCorrection<T>
    * @param pairs specifies the p values array which has to be already
    *        in sorted order!
    */
-  default void enforcePValueMonotony(List<Item2PValue<T> > pairs)
+  default void enforcePValueMonotony(List<? extends Item2PValue<T> > pairs)
   {
     int m = pairs.size();
 


### PR DESCRIPTION
To make classes extending Item2Pval also accepted by MTC classes