### PR TITLE
Make score distribution generic

### DIFF
--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/MergeScoresCommand.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/MergeScoresCommand.java
@@ -37,10 +37,10 @@ public class MergeScoresCommand {
   private MergeScoresOptions options;
 
   /** The loaded distributions. */
-  private SortedMap<Integer, List<ScoreDistribution>> loadedDists = new TreeMap<>();
+  private SortedMap<Integer, List<ScoreDistribution<Integer>>> loadedDists = new TreeMap<>();
 
   /** The merged distributions. */
-  private SortedMap<Integer, ScoreDistribution> mergedDists = new TreeMap<>();
+  private SortedMap<Integer, ScoreDistribution<Integer>> mergedDists = new TreeMap<>();
 
   public MergeScoresCommand(MergeScoresOptions options) {
     this.options = options;
@@ -64,8 +64,8 @@ public class MergeScoresCommand {
       LOGGER.info("Loading {}", inputPath);
       try (final ScoreDistributionReader reader =
           new TextFileScoreDistributionReader(new File(inputPath))) {
-        Map<Integer, ScoreDistribution> distributions = reader.readAll();
-        for (Entry<Integer, ScoreDistribution> e : distributions.entrySet()) {
+        Map<Integer, ScoreDistribution<Integer>> distributions = reader.readAll();
+        for (Entry<Integer, ScoreDistribution<Integer>> e : distributions.entrySet()) {
           if (!loadedDists.containsKey(e.getKey())) {
             loadedDists.put(e.getKey(), new ArrayList<>());
           }
@@ -82,7 +82,7 @@ public class MergeScoresCommand {
   private void mergeDistributions() {
     LOGGER.info("Merging distributions...");
 
-    for (Entry<Integer, List<ScoreDistribution>> e : loadedDists.entrySet()) {
+    for (Entry<Integer, List<ScoreDistribution<Integer>>> e : loadedDists.entrySet()) {
       mergedDists.put(e.getKey(), ScoreDistributions.merge(e.getValue()));
     }
 
@@ -92,7 +92,7 @@ public class MergeScoresCommand {
   private void writeResult() {
     LOGGER.info("Writing result...");
     try (ScoreDistributionWriter writer = buildWriter()) {
-      for (Entry<Integer, ScoreDistribution> e : mergedDists.entrySet()) {
+      for (Entry<Integer, ScoreDistribution<Integer>> e : mergedDists.entrySet()) {
         writer.write(e.getKey(), e.getValue(), options.getResampleToPoints());
       }
     } catch (IOException | PhenolException e) {

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/scoredist/ObjectScoreDistribution.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/scoredist/ObjectScoreDistribution.java
@@ -13,13 +13,13 @@ import java.util.TreeMap;
  * @author <a href="mailto:manuel.holtgrewe@bihealth.de">Manuel Holtgrewe</a>
  * @author <a href="mailto:sebastian.koehler@charite.de">Sebastian Koehler</a>
  */
-public final class ObjectScoreDistribution implements Serializable {
+public final class ObjectScoreDistribution<T extends Serializable> implements Serializable {
 
   /** Serial UId for serialization. */
   private static final long serialVersionUID = 1L;
 
   /** "World object" identifier. */
-  private final int objectId;
+  private final T objectId;
 
   /** Number of terms used for precomputing scores with. */
   private final int numTerms;
@@ -41,7 +41,7 @@ public final class ObjectScoreDistribution implements Serializable {
    * @param cumulativeFrequencies Cumulative frequencies of the scores.
    */
   public ObjectScoreDistribution(
-      int objectId, int numTerms, int sampleSize, SortedMap<Double, Double> cumulativeFrequencies) {
+      T objectId, int numTerms, int sampleSize, SortedMap<Double, Double> cumulativeFrequencies) {
     this.objectId = objectId;
     this.numTerms = numTerms;
     this.sampleSize = sampleSize;
@@ -82,7 +82,7 @@ public final class ObjectScoreDistribution implements Serializable {
   }
 
   /** @return The world object Id for which the score has been precomputed. */
-  public int getObjectId() {
+  public T getObjectId() {
     return objectId;
   }
 

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/scoredist/ScoreDistribution.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/scoredist/ScoreDistribution.java
@@ -9,7 +9,7 @@ import java.util.Map;
  *
  * @author <a href="mailto:manuel.holtgrewe@bihealth.de">Manuel Holtgrewe</a>
  */
-public final class ScoreDistribution implements Serializable {
+public final class ScoreDistribution<T extends Serializable> implements Serializable {
 
   /** Serial UId for serialization. */
   private static final long serialVersionUID = 1L;
@@ -18,7 +18,7 @@ public final class ScoreDistribution implements Serializable {
   private final int numTerms;
 
   /** Mapping from "world object" Id to score distribution. */
-  private final Map<Integer, ObjectScoreDistribution> objectScoreDistributions;
+  private final Map<Integer, ObjectScoreDistribution<T>> objectScoreDistributions;
 
   /**
    * Constructor.
@@ -28,7 +28,7 @@ public final class ScoreDistribution implements Serializable {
    *     ObjectScoreDistribution}.
    */
   public ScoreDistribution(
-      int numTerms, Map<Integer, ObjectScoreDistribution> objectScoreDistributions) {
+      int numTerms, Map<Integer, ObjectScoreDistribution<T>> objectScoreDistributions) {
     this.numTerms = numTerms;
     this.objectScoreDistributions = objectScoreDistributions;
   }
@@ -49,7 +49,7 @@ public final class ScoreDistribution implements Serializable {
    * @param objectId "World object" Id to get {@link ObjectScoreDistribution} for.
    * @return The object score distributions for the given <code>objectId</code>.
    */
-  public ObjectScoreDistribution getObjectScoreDistribution(int objectId) {
+  public ObjectScoreDistribution<T> getObjectScoreDistribution(int objectId) {
     return objectScoreDistributions.get(objectId);
   }
 

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/scoredist/ScoreDistributions.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/scoredist/ScoreDistributions.java
@@ -1,5 +1,6 @@
 package org.monarchinitiative.phenol.ontology.scoredist;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -23,7 +24,7 @@ public final class ScoreDistributions {
    * @return Merge result.
    * @throws CannotMergeScoreDistributions In case of problems with {@code distributions}.
    */
-  public static ScoreDistribution merge(Collection<ScoreDistribution> distributions) {
+  public static <T extends Serializable> ScoreDistribution merge(Collection<ScoreDistribution<T>> distributions) {
     if (distributions.isEmpty()) {
       throw new CannotMergeScoreDistributions("Cannot merge zero ScoreDistributions objects.");
     }
@@ -31,10 +32,10 @@ public final class ScoreDistributions {
       throw new CannotMergeScoreDistributions("Different numbers of terms used for precomputation");
     }
 
-    Map<Integer, ObjectScoreDistribution> mapping = new HashMap<>();
-    for (ScoreDistribution d : distributions) {
+    Map<Integer, ObjectScoreDistribution<T>> mapping = new HashMap<>();
+    for (ScoreDistribution<T> d : distributions) {
       for (Integer objectId : d.getObjectIds()) {
-        final ObjectScoreDistribution dist = d.getObjectScoreDistribution(objectId);
+        final ObjectScoreDistribution<T> dist = d.getObjectScoreDistribution(objectId);
         if (mapping.containsKey(objectId)) {
           throw new CannotMergeScoreDistributions("Duplicate object ID " + objectId + " detected");
         } else {
@@ -52,7 +53,7 @@ public final class ScoreDistributions {
    * @param distributions {@link ScoreDistribution}s to merge.
    * @return Merge result.
    */
-  public static ScoreDistribution merge(ScoreDistribution... distributions) {
+  public static <T extends Serializable> ScoreDistribution<T> merge(ScoreDistribution<T>... distributions) {
     return merge(Arrays.asList(distributions));
   }
 }

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/scoredist/ScoreDistributions.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/scoredist/ScoreDistributions.java
@@ -24,7 +24,7 @@ public final class ScoreDistributions {
    * @return Merge result.
    * @throws CannotMergeScoreDistributions In case of problems with {@code distributions}.
    */
-  public static <T extends Serializable> ScoreDistribution merge(Collection<ScoreDistribution<T>> distributions) {
+  public static <T extends Serializable> ScoreDistribution merge(Collection<? extends ScoreDistribution<T>> distributions) {
     if (distributions.isEmpty()) {
       throw new CannotMergeScoreDistributions("Cannot merge zero ScoreDistributions objects.");
     }

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/scoredist/SimilarityScoreSampling.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/scoredist/SimilarityScoreSampling.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author <a href="mailto:manuel.holtgrewe@bihealth.de">Manuel Holtgrewe</a>
  */
-public final class SimilarityScoreSampling {
+public final class SimilarityScoreSampling<T> {
 
   /** {@link Logger} object to use. */
   private static final Logger LOGGER = LoggerFactory.getLogger(SimilarityScoreSampling.class);
@@ -107,11 +107,11 @@ public final class SimilarityScoreSampling {
     progressReport.start();
 
     // Setup the task to execute in parallel, with concurrent hash map for collecting results.
-    final ConcurrentHashMap<Integer, ObjectScoreDistribution> distributions = new ConcurrentHashMap<>();
+    final ConcurrentHashMap<Integer, ObjectScoreDistribution<Integer>> distributions = new ConcurrentHashMap<>();
     IntConsumer task =
       objectId -> {
           try {
-            final ObjectScoreDistribution dist =
+            final ObjectScoreDistribution<Integer> dist =
                 performComputation(objectId, labels.get(objectId), numTerms);
             distributions.put(dist.getObjectId(), dist);
             progressReport.incCurrent();

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/scoredist/ObjectScoreDistributionTest.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/scoredist/ObjectScoreDistributionTest.java
@@ -5,21 +5,27 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.common.collect.ImmutableSortedMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.monarchinitiative.phenol.ontology.data.TermId;
 
 public class ObjectScoreDistributionTest {
 
-  ObjectScoreDistribution objDist;
+  ObjectScoreDistribution<Integer> objDist;
+  ObjectScoreDistribution<TermId> objDist2;
 
   @BeforeEach
   public void setUp() {
     objDist =
-        new ObjectScoreDistribution(1, 2, 10, ImmutableSortedMap.of(0.1, 0.1, 0.5, 0.5, 0.9, 0.9));
+      (ObjectScoreDistribution<Integer>) new ObjectScoreDistribution(1, 2, 10, ImmutableSortedMap.of(0.1, 0.1, 0.5, 0.5, 0.9, 0.9));
+
+    objDist2 =
+      new ObjectScoreDistribution<>(TermId.of("HP:test"), 2, 10, ImmutableSortedMap.of(0.1, 0.1, 0.5, 0.5, 0.9, 0.9));
+
   }
 
   @Test
   public void testQueries() {
     assertEquals(2, objDist.getNumTerms());
-    assertEquals(1, objDist.getObjectId());
+    assertEquals(1, objDist.getObjectId().intValue());
     assertEquals(10, objDist.getSampleSize());
   }
 
@@ -33,4 +39,10 @@ public class ObjectScoreDistributionTest {
     assertEquals(0.42, objDist.estimatePValue(0.8), 0.01);
     assertEquals(0.0, objDist.estimatePValue(0.99), 0.01);
   }
+
+  @Test
+  public void testGenericId() {
+    assertEquals("HP:test", objDist2.getObjectId().getValue());
+  }
+
 }

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/scoredist/ScoreDistributionTest.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/scoredist/ScoreDistributionTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 public class ScoreDistributionTest {
 
-  ScoreDistribution dist;
+  ScoreDistribution<Integer> dist;
 
   @BeforeEach
   public void setUp() {
@@ -26,6 +26,6 @@ public class ScoreDistributionTest {
   public void testQueries() {
     assertEquals(2, dist.getNumTerms());
     assertEquals("[1]", dist.getObjectIds().toString());
-    assertEquals(1, dist.getObjectScoreDistribution(1).getObjectId());
+    assertEquals(1, dist.getObjectScoreDistribution(1).getObjectId().intValue());
   }
 }

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/scoredist/H2ScoreDistributionWriter.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/scoredist/H2ScoreDistributionWriter.java
@@ -1,6 +1,7 @@
 package org.monarchinitiative.phenol.io.scoredist;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -145,9 +146,9 @@ public final class H2ScoreDistributionWriter implements ScoreDistributionWriter 
   }
 
   @Override
-  public void write(int numTerms, ScoreDistribution scoreDistribution, int resolution)
+  public <T extends Serializable> void write(int numTerms, ScoreDistribution<T> scoreDistribution, int resolution)
       throws PhenolException {
-    for (int objectId : scoreDistribution.getObjectIds()) {
+    for (Integer objectId : scoreDistribution.getObjectIds()) {
       final ObjectScoreDistribution dist = scoreDistribution.getObjectScoreDistribution(objectId);
       writeObjectScoreDistribution(numTerms, dist, resolution);
     }
@@ -162,7 +163,7 @@ public final class H2ScoreDistributionWriter implements ScoreDistributionWriter 
    * @throws PhenolException In case of problems when writing to database.
    */
   private void writeObjectScoreDistribution(
-      int numTerms, ObjectScoreDistribution dist, int resolution) throws PhenolException {
+      int numTerms, ObjectScoreDistribution<Integer> dist, int resolution) throws PhenolException {
     final double scores[];
     final double pValues[];
 

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/scoredist/ScoreDistributionReader.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/scoredist/ScoreDistributionReader.java
@@ -2,6 +2,7 @@ package org.monarchinitiative.phenol.io.scoredist;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Map;
 
 import org.monarchinitiative.phenol.base.PhenolException;
@@ -13,7 +14,7 @@ import org.monarchinitiative.phenol.ontology.scoredist.ScoreDistribution;
  *
  * @author <a href="mailto:manuel.holtgrewe@bihealth.de">Manuel Holtgrewe</a>
  */
-public interface ScoreDistributionReader extends Closeable {
+public interface ScoreDistributionReader<T extends Serializable> extends Closeable {
 
   /**
    * Read for the given {@code termCount} and {@code objectId}.
@@ -23,7 +24,7 @@ public interface ScoreDistributionReader extends Closeable {
    * @return {@link ObjectScoreDistribution} with the empirical distribution for the query.
    * @throws PhenolException In the case of problems when reading and parsing.
    */
-  ObjectScoreDistribution readForTermCountAndObject(int termCount, int objectId)
+  ObjectScoreDistribution<T> readForTermCountAndObject(int termCount, int objectId)
       throws PhenolException;
 
   /**
@@ -33,7 +34,7 @@ public interface ScoreDistributionReader extends Closeable {
    * @return {@link ScoreDistribution} for the given {@code termCount}.
    * @throws PhenolException In the case of problems when reading or parsing.
    */
-  ScoreDistribution readForTermCount(int termCount) throws PhenolException;
+  ScoreDistribution<T> readForTermCount(int termCount) throws PhenolException;
 
   /**
    * Read all entries and return mapping from term count to {@link ScoreDistribution} object.
@@ -41,7 +42,7 @@ public interface ScoreDistributionReader extends Closeable {
    * @return Resulting score distributions from the file.
    * @throws PhenolException In the case of problems when reading or parsing.
    */
-  Map<Integer, ScoreDistribution> readAll() throws PhenolException;
+  Map<Integer, ScoreDistribution<T>> readAll() throws PhenolException;
 
   void close() throws IOException;
 }

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/scoredist/ScoreDistributionWriter.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/scoredist/ScoreDistributionWriter.java
@@ -1,6 +1,7 @@
 package org.monarchinitiative.phenol.io.scoredist;
 
 import java.io.Closeable;
+import java.io.Serializable;
 
 import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.ontology.scoredist.ScoreDistribution;
@@ -18,7 +19,7 @@ public interface ScoreDistributionWriter extends Closeable {
    * @throws PhenolException In the case that there was a problem writing.
    * @see #write(int, ScoreDistribution, int)
    */
-  default void write(int numTerms, ScoreDistribution scoreDistribution) throws PhenolException {
+  default <T extends Serializable> void write(int numTerms, ScoreDistribution<T> scoreDistribution) throws PhenolException {
     write(numTerms, scoreDistribution, 100);
   }
 
@@ -31,6 +32,6 @@ public interface ScoreDistributionWriter extends Closeable {
    *     resampling.
    * @throws PhenolException In the case that there was a problem writing.
    */
-  void write(int numTerms, ScoreDistribution scoreDistribution, int resolution)
+  <T extends Serializable> void write(int numTerms, ScoreDistribution<T> scoreDistribution, int resolution)
       throws PhenolException;
 }

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/scoredist/TextFileScoreDistributionWriter.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/scoredist/TextFileScoreDistributionWriter.java
@@ -3,6 +3,7 @@ package org.monarchinitiative.phenol.io.scoredist;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -38,9 +39,9 @@ public class TextFileScoreDistributionWriter implements ScoreDistributionWriter 
   }
 
   @Override
-  public void write(int numTerms, ScoreDistribution scoreDistribution, int resolution) {
+  public <T extends Serializable> void write(int numTerms, ScoreDistribution<T> scoreDistribution, int resolution) {
     for (int objectId : scoreDistribution.getObjectIds()) {
-      final ObjectScoreDistribution dist = scoreDistribution.getObjectScoreDistribution(objectId);
+      final ObjectScoreDistribution<T> dist = scoreDistribution.getObjectScoreDistribution(objectId);
       final List<Double> scores = dist.observedScores();
       final ArrayList<String> points = new ArrayList<>();
       if (resolution != 0) {


### PR DESCRIPTION
The original ScoreDistribution classes requires using Integers as keys. It feels pretty restricted. Now it is more flexible. However, it will break old code (now requires class variable, which is easy to fix). Does this sound a good fix?