### PR TITLE
Synonym from obographs

### DIFF
--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationFileParser.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationFileParser.java
@@ -71,6 +71,8 @@ public class HpoAnnotationFileParser {
   }
 
 
+
+
     /**
      * Parse a single HPO Annotation file. If {@code faultTolerant} is set to true, then we will parse as
      * much as we can of an annotation file and return the {@link HpoAnnotationModel} object, even if one or more

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/TermSynonym.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/TermSynonym.java
@@ -24,6 +24,17 @@ public final class TermSynonym {
   /** List of term xRefs, <code>null</code> if missing. */
   private final List<TermXref> termXrefs;
 
+  /** AN enumeration of the possible synonym types (note: most synonyms in the current HPO do
+   * not have a specific type; we encode these as NONE.
+   */
+  enum SynonymType {
+    NONE,ABBREVIATION, LAYPERSON_TERM, OBSOLETE_SYNONYM, PLURAL_FORM, UK_SPELLING
+  }
+  /** The kind of synonym (default, and by far the most common, is no specific synonym type --NONE). */
+  SynonymType synonymType = SynonymType.NONE;
+
+  /** Synonym type, e.g., layperson */
+
   /**
    * Constructor.
    *
@@ -32,11 +43,32 @@ public final class TermSynonym {
    * @param synonymTypeName Optional synonym type name, <code>null</code> if missing.
    * @param termXrefs Optional dbxref list, <code>null</code> if missing.
    */
-  public TermSynonym(String value, TermSynonymScope scope, String synonymTypeName, List<TermXref> termXrefs) {
+  public TermSynonym(String value, TermSynonymScope scope, String synonymTypeName, List<TermXref> termXrefs, String synType) {
     this.value = value;
     this.scope = scope;
     this.synonymTypeName = synonymTypeName;
     this.termXrefs = termXrefs;
+    if (synType != null && ! synType.isEmpty()) {
+      switch(synType) {
+        case "abbreviation":
+          this.synonymType = SynonymType.ABBREVIATION;
+          break;
+        case "layperson term":
+          this.synonymType = SynonymType.LAYPERSON_TERM;
+          break;
+        case "obsolete synonym":
+          this.synonymType = SynonymType.OBSOLETE_SYNONYM;
+          break;
+        case "plural form":
+          this.synonymType = SynonymType.PLURAL_FORM;
+          break;
+        case "UK spelling":
+          this.synonymType = SynonymType.UK_SPELLING;
+          break;
+        default:
+          System.err.println("[ERROR] Did not recognize synonym type: " + synType);
+      }
+    }
   }
 
   public String getValue() {
@@ -50,13 +82,34 @@ public final class TermSynonym {
   public String getSynonymTypeName() {
     return synonymTypeName;
   }
-  
+
   public List<TermXref> getTermXrefs() {
     return termXrefs;
   }
 
   @Override
   public String toString() {
+    String synString = synonymTypeName;
+    if (! synonymType.equals(SynonymType.NONE)) {
+      switch (synonymType) {
+        case PLURAL_FORM:
+          synString += " [plural form]";
+          break;
+        case UK_SPELLING:
+          synString += " [UK spelling]";
+          break;
+        case  OBSOLETE_SYNONYM:
+          synString += " [obsolete synonym]";
+          break;
+        case LAYPERSON_TERM:
+          synString += " [layperson term]";
+          break;
+        case ABBREVIATION:
+          synString += " [abbreviation]";
+          break;
+      }
+    }
+
     return "TermSynonym [value="
         + value
         + ", scope="

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/TermSynonym.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/TermSynonym.java
@@ -1,5 +1,6 @@
 package org.monarchinitiative.phenol.ontology.data;
 
+import javax.swing.plaf.synth.SynthOptionPaneUI;
 import java.util.List;
 
 /**
@@ -28,7 +29,8 @@ public final class TermSynonym {
    * not have a specific type; we encode these as NONE.
    */
   enum SynonymType {
-    NONE,ABBREVIATION, LAYPERSON_TERM, OBSOLETE_SYNONYM, PLURAL_FORM, UK_SPELLING
+    NONE,ABBREVIATION, LAYPERSON_TERM, OBSOLETE_SYNONYM, PLURAL_FORM, UK_SPELLING, IUPAC_NAME, INN, BRAND_NAME, IN_PART,
+    SYNONYM, BLAST_NAME, GENBANK_COMMON_NAME, COMMON_NAME
   }
   /** The kind of synonym (default, and by far the most common, is no specific synonym type --NONE). */
   SynonymType synonymType = SynonymType.NONE;
@@ -51,19 +53,48 @@ public final class TermSynonym {
     if (synType != null && ! synType.isEmpty()) {
       switch(synType) {
         case "abbreviation":
+        case "http://purl.obolibrary.org/obo/HP_0045077":
           this.synonymType = SynonymType.ABBREVIATION;
           break;
         case "layperson term":
+        case "http://purl.obolibrary.org/obo/hp#layperson":
           this.synonymType = SynonymType.LAYPERSON_TERM;
           break;
+        case "http://purl.obolibrary.org/obo/HP_0031859":
         case "obsolete synonym":
           this.synonymType = SynonymType.OBSOLETE_SYNONYM;
           break;
         case "plural form":
+        case "http://purl.obolibrary.org/obo/HP_0045078":
           this.synonymType = SynonymType.PLURAL_FORM;
           break;
+        case "http://purl.obolibrary.org/obo/HP_0045076":
         case "UK spelling":
           this.synonymType = SynonymType.UK_SPELLING;
+          break;
+        case "http://purl.obolibrary.org/obo/ecto#IUPAC_NAME":
+          this.synonymType = SynonymType.IUPAC_NAME;
+          break;
+        case "http://purl.obolibrary.org/obo/ecto#INN":
+          this.synonymType = SynonymType.INN;
+          break;
+        case "http://purl.obolibrary.org/obo/ecto#BRAND_NAME":
+          this.synonymType = SynonymType.BRAND_NAME;
+          break;
+        case "http://purl.obolibrary.org/obo/ecto#in_part":
+          this.synonymType = SynonymType.IN_PART;
+          break;
+        case "http://purl.obolibrary.org/obo/ecto#synonym":
+          this.synonymType = SynonymType.SYNONYM;
+          break;
+        case "http://purl.obolibrary.org/obo/ecto#blast_name":
+          this.synonymType = SynonymType.BLAST_NAME;
+          break;
+        case "http://purl.obolibrary.org/obo/ecto#genbank_common_name":
+          this.synonymType = SynonymType.GENBANK_COMMON_NAME;
+          break;
+        case "http://purl.obolibrary.org/obo/ecto#common_name":
+          this.synonymType = SynonymType.COMMON_NAME;
           break;
         default:
           System.err.println("[ERROR] Did not recognize synonym type: " + synType);
@@ -120,4 +151,33 @@ public final class TermSynonym {
         + termXrefs
         + "]";
   }
+
+
+  public boolean hasSynonymType() {
+    return (! this.synonymType.equals(SynonymType.NONE));
+  }
+
+  public boolean isLayperson() {
+    return this.synonymType.equals(SynonymType.LAYPERSON_TERM);
+  }
+
+  public boolean isAbbreviation() {
+    return this.synonymType.equals(SynonymType.ABBREVIATION);
+  }
+
+  public boolean isUKspelling() {
+    return this.synonymType.equals(SynonymType.UK_SPELLING);
+  }
+
+  public boolean isPluralForm() {
+    return this.synonymType.equals(SynonymType.PLURAL_FORM);
+  }
+
+  public boolean isObsoleteSynonym() {
+    return this.synonymType.equals(SynonymType.OBSOLETE_SYNONYM);
+  }
+
+
+
+
 }

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/data/TermSynonymTest.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/data/TermSynonymTest.java
@@ -6,7 +6,7 @@ import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ImmutableTermSynonymTest {
+class TermSynonymTest {
 
   private TermSynonym termSynonym;
 
@@ -17,7 +17,8 @@ class ImmutableTermSynonymTest {
             "synonym",
             TermSynonymScope.EXACT,
             "BRITISH_ENGLISH",
-            ImmutableList.of(new TermXref(TermId.of("HP:0000001"),"term description")));
+            ImmutableList.of(new TermXref(TermId.of("HP:0000001"),"term description")),
+          "layperson term");
   }
 
   @Test

--- a/phenol-io/pom.xml
+++ b/phenol-io/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
        <groupId>org.geneontology</groupId>
        <artifactId>obographs</artifactId>
-       <version>0.1.1</version>
+       <version>0.2.0</version>
        <exclusions>
           <exclusion>
               <groupId>com.fasterxml.jackson.core</groupId>

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obographs/OboGraphTermFactory.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obographs/OboGraphTermFactory.java
@@ -124,6 +124,7 @@ public class OboGraphTermFactory {
       } else if (pred.equals(SynonymPropertyValue.PREDS.hasRelatedSynonym.toString())) {
         scope = TermSynonymScope.RELATED;
       }
+      String synonymType = spv.getSynonymType();
 
       // Map the synonym's type name.
       String synonymTypeName = String.join(", ", spv.getTypes());
@@ -132,7 +133,7 @@ public class OboGraphTermFactory {
       List<String> xrefs = spv.getXrefs();
       List<TermXref> termXrefs = mapXref(xrefs);
 
-      TermSynonym its = new TermSynonym(spv.getVal(), scope, synonymTypeName, termXrefs);
+      TermSynonym its = new TermSynonym(spv.getVal(), scope, synonymTypeName, termXrefs, synonymType);
       termSynonymBuilder.add(its);
     }
 

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderHpoTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderHpoTest.java
@@ -8,6 +8,7 @@ import org.monarchinitiative.phenol.graph.IdLabeledEdge;
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.monarchinitiative.phenol.ontology.data.TermSynonym;
 import org.obolibrary.oboformat.model.OBODoc;
 import org.obolibrary.oboformat.parser.OBOFormatParser;
 
@@ -15,34 +16,38 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.monarchinitiative.phenol.ontology.data.TermSynonymScope.EXACT;
+import static org.monarchinitiative.phenol.ontology.data.TermSynonymScope.RELATED;
 
 public class OntologyLoaderHpoTest {
 
-  private Ontology ontology;
+  private Ontology hpo;
 
-  public OntologyLoaderHpoTest() throws PhenolException {
-    this.ontology = OntologyLoader.loadOntology(Paths.get("src/test/resources/hp_head.obo").toFile());
+  public OntologyLoaderHpoTest() {
+    this.hpo = OntologyLoader.loadOntology(Paths.get("src/test/resources/hp_head.obo").toFile());
   }
 
   @Test
   public void testParseHpoHead() {
-    final DefaultDirectedGraph<TermId, IdLabeledEdge> graph = ontology.getGraph();
+    final DefaultDirectedGraph<TermId, IdLabeledEdge> graph = hpo.getGraph();
     assertNotNull(graph);
   }
 
   @Test
   public void testGetRightNumberOfTerms() {
     int expectedTermCount = 22; // there are 22 non-obsolete terms in hp_head.obo
-    assertEquals(expectedTermCount, ontology.countAllTerms());
+    assertEquals(expectedTermCount, hpo.countAllTerms());
   }
 
   @Test
   public void testGetRootTerm() {
     TermId rootId = TermId.of("HP:0000001");
-    assertEquals(rootId, ontology.getRootTermId());
+    assertEquals(rootId, hpo.getRootTermId());
   }
 
   @Test
@@ -52,7 +57,7 @@ public class OntologyLoaderHpoTest {
     TermId tid2 = TermId.of("HP:0000006");
     TermId tid3 = TermId.of("HP:0000007");
     TermId tid4 = TermId.of("HP:0000118");
-    Map<TermId, Term> termMap = ontology.getTermMap();
+    Map<TermId, Term> termMap = hpo.getTermMap();
     assertTrue(termMap.containsKey(tid1));
     assertTrue(termMap.containsKey(tid2));
     assertTrue(termMap.containsKey(tid3));
@@ -72,9 +77,9 @@ public class OntologyLoaderHpoTest {
     System.out.println("Finished in " + Duration.between(start, end).toMillis() + " ms");
   }
 
-  @Disabled
+ // @Disabled
   @Test
-  public void testParseFullHpo() throws Exception {
+  public void testParseFullHpo() {
 //    for (int i = 0; i < 10; i++) {
       System.out.println("Starting full HPO load");
       Instant start = Instant.now();
@@ -101,4 +106,65 @@ public class OntologyLoaderHpoTest {
     System.out.println("Finished in " + Duration.between(start, end).toMillis() + " ms");
 //    }
   }
+
+  @Test
+  void ifHpoNotNull_thenOK() {
+    assertNotNull(hpo);
+  }
+
+  @Test
+  void ifHpoHas22Terms_thenOK() {
+    int expectedTermCount = 22; // hpo_small.obo
+    assertEquals(expectedTermCount, hpo.countAllTerms());
+  }
+
+  @Test
+  void testModeOfInheritanceTerm() {
+    TermId mode = TermId.of("HP:0000005");
+    Term moiTerm = hpo.getTermMap().get(mode);
+    assertNotNull(moiTerm);
+    List<TermSynonym> synonyms =moiTerm.getSynonyms();
+    // HP:0000005 has one EXACT synonym
+    assertEquals(1, synonyms.size());
+    TermSynonym syn = synonyms.get(0);
+    assertEquals(EXACT,syn.getScope());
+    assertFalse(syn.hasSynonymType());
+  }
+
+
+  @Test
+  void trestAbnormalityOfTheEye() {
+    TermId eyeId = TermId.of("HP:0000478");
+    Term eye = hpo.getTermMap().get(eyeId);
+    assertNotNull(eye);
+    assertEquals("Abnormality of the eye", eye.getName());
+    // There are three synonyms, all of them are layperson
+    List<TermSynonym> synonyms =eye.getSynonyms();
+    assertEquals(3, synonyms.size());
+    Optional<TermSynonym> opt1 = synonyms.stream().filter(s -> s.getValue().equals("Abnormal eye")).findFirst();
+    assertTrue(opt1.isPresent());
+    TermSynonym syn1 = opt1.get();
+    assertNotNull(syn1);
+    assertEquals("Abnormal eye", syn1.getValue());
+    assertEquals(EXACT, syn1.getScope());
+    assertTrue(syn1.isLayperson());
+    // "Abnormality of the eye"
+    Optional<TermSynonym> opt2 = synonyms.stream().filter(s -> s.getValue().equals("Abnormality of the eye")).findFirst();
+    assertTrue(opt2.isPresent());
+    TermSynonym syn2 = opt2.get();
+    assertNotNull(syn2);
+    assertEquals(EXACT, syn2.getScope());
+    assertTrue(syn2.isLayperson());
+  //  "Eye disease"
+    Optional<TermSynonym> opt3 = synonyms.stream().filter(s -> s.getValue().equals("Eye disease")).findFirst();
+    assertTrue(opt3.isPresent());
+    TermSynonym syn3 = opt3.get();
+    assertNotNull(syn3);
+    assertEquals(RELATED, syn3.getScope());
+    assertTrue(syn3.isLayperson());
+
+
+  }
+
+
 }

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.monarchinitiative.phenol.ontology.data.*;
 import org.monarchinitiative.phenol.graph.IdLabeledEdge;
 import org.jgrapht.graph.DefaultDirectedGraph;
@@ -20,6 +21,17 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:HyeongSikKim@lbl.gov">HyeongSik Kim</a>
  */
 class OntologyLoaderTest {
+
+  private static Ontology hpo;
+
+  @BeforeAll
+  static void init() {
+    Path hpoPath = Paths.get("src/test/resources/hp_head.obo");
+    hpo = OntologyLoader.loadOntology(hpoPath.toFile());
+
+  }
+
+
 
   @Test
   void testNCITLoad() throws Exception {
@@ -147,4 +159,25 @@ class OntologyLoaderTest {
       .map(TermId::getPrefix)
       .collect(toSet()));
   }
+
+  @Test
+  void ifHpoNotNull_thenOK() {
+    assertNotNull(hpo);
+  }
+
+  @Test
+  void ifHpoHas22Terms_thenOK() {
+    int expectedTermCount = 22; // hpo_small.obo
+    assertEquals(expectedTermCount, hpo.countAllTerms());
+  }
+
+  @Test
+  void testModeOfInheritanceTerm() {
+    TermId mode = TermId.of("HP:0000005");
+    Term moiTerm = hpo.getTermMap().get(mode);
+    assertNotNull(moiTerm);
+  }
+
+
+
 }

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderTest.java
@@ -160,24 +160,6 @@ class OntologyLoaderTest {
       .collect(toSet()));
   }
 
-  @Test
-  void ifHpoNotNull_thenOK() {
-    assertNotNull(hpo);
-  }
-
-  @Test
-  void ifHpoHas22Terms_thenOK() {
-    int expectedTermCount = 22; // hpo_small.obo
-    assertEquals(expectedTermCount, hpo.countAllTerms());
-  }
-
-  @Test
-  void testModeOfInheritanceTerm() {
-    TermId mode = TermId.of("HP:0000005");
-    Term moiTerm = hpo.getTermMap().get(mode);
-    assertNotNull(moiTerm);
-  }
-
 
 
 }


### PR DESCRIPTION
Jules -- I have extended TermSynonym and OboGraphTermFactory to deal with the synonym type (e.g., layperson or UK spelling). I have implemented the TermSynonym type as an enumeration and initially with a series of ``bool isLayperson()`` methods, but then I saw that our other ontologies have lots of different synoynm types. 
Do you think it would be better to make the enumeration ``SynonymType`` public and return it directly so that client code can test ``if (mysynonymType.equals(SynonymType.LAYPERSON_TERM) {....```?

```
  enum SynonymType {
    NONE,ABBREVIATION, LAYPERSON_TERM, OBSOLETE_SYNONYM, PLURAL_FORM, UK_SPELLING, IUPAC_NAME, INN, BRAND_NAME, IN_PART,
    SYNONYM, BLAST_NAME, GENBANK_COMMON_NAME, COMMON_NAME
  }
```