### PR TITLE
mim2geneMedgen parser in separate class

### DIFF
--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/assoc/Gene2DiseaseAssociationParser.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/assoc/Gene2DiseaseAssociationParser.java
@@ -57,6 +57,11 @@ public class Gene2DiseaseAssociationParser {
     parseMim2geneAndGeneInfo(homoSapiensGeneInfoFile, mim2geneMedgenFile);
   }
 
+
+
+
+
+
   /**
    * This constructor should be chosen to get data about disease links from mim2gene_medgen and
    * Homo sapiens gene info and Orphanet.
@@ -126,6 +131,10 @@ public class Gene2DiseaseAssociationParser {
     int added = size_after - size_before;
     System.out.printf("Added %d Orphanet entries to association map (total size: %d).\n", added, size_after);
   }
+
+
+
+
 
 
   /**

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/assoc/HpoAssociationParser.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/assoc/HpoAssociationParser.java
@@ -89,7 +89,27 @@ public class HpoAssociationParser {
     ingestDisease2GeneAssociations();
   }
 
-
+  /**
+   * Use this constructor to parse everything except the Orphanet to gene file.
+   * @param geneInfoFile
+   * @param mim2geneMedgenFile
+   * @param phenotypeHpoaFile
+   * @param hpoOntology
+   */
+  public HpoAssociationParser(File geneInfoFile,
+                              File mim2geneMedgenFile,
+                              File phenotypeHpoaFile,
+                              Ontology hpoOntology){
+    this.hpoOntology = hpoOntology;
+    this.homoSapiensGeneInfoFile = geneInfoFile;
+    this.mim2geneMedgenFile = mim2geneMedgenFile;
+    this.orphaToGeneFile = null;
+    this.phenotypeDotHpoaFile = phenotypeHpoaFile;
+    // The following skips the orphaToGeneFile to gene file because it is null
+    // TODO this class is not elegant, it needs refactoring.
+    ingestDisease2GeneAssociations();
+    ingestPhenotypeHpoaFile();
+  }
 
   public HpoAssociationParser(File geneInfoFile,
                               File mim2geneMedgenFile,

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/assoc/Mim2GeneMedgenParser.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/assoc/Mim2GeneMedgenParser.java
@@ -1,0 +1,103 @@
+package org.monarchinitiative.phenol.annotations.assoc;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import org.monarchinitiative.phenol.annotations.formats.Gene;
+import org.monarchinitiative.phenol.annotations.formats.hpo.AssociationType;
+import org.monarchinitiative.phenol.annotations.formats.hpo.GeneToAssociation;
+import org.monarchinitiative.phenol.base.PhenolRuntimeException;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+
+import java.io.*;
+import java.util.Map;
+
+/**
+ * <p>Parse mim2gene_medgen, which is available at https://ftp.ncbi.nih.gov/gene/DATA/mim2gene_medgen. This file contains
+ * links between NCBI Gene Ids and OMIM identifiers for Mendelian and polygenic diseases. The class offers two
+ * static functions that return a Multimap whose key is a TermId for an OMIM id, e.g., OMIM:600123. The value of the
+ * multimap is a collection of GeneToAssociation objects, which in turn specify genes (as TermIds and Gene Symbols)
+ * and the association type (Mendelian or Polygenic).</p>
+ * <p>The class requires data from the NCBI Gene Homo_sapiens.gene_info.gz to get the gene symbol for NCBI Gene ids
+ * becuase the mim2gene_medgen only has the ids (for instance, mim2gene_medgen represents the fibrillin-1 gene
+ * by its NCBI Gene id of 2200, and we extract the corresponding gene symbol FBN1 from Homo_sapiens.gene_info.gz).</p>
+ * <p>The class can be contructed from paths to both file or one can alternatively pass Map containing the
+ * id to symbol data from Homo_sapiens.gene_info.gz.</p>
+ * <pre>{@code
+ * String hsGeneInfoPath = "..."; // path to Homo_sapiens.gene_info.gz file
+ * String mim2geneMedgenPath = "...";// path to mim2gene_medgen
+ * // Option 1
+ * Multimap<TermId, GeneToAssociation> idToAssociationMap
+ *    = Mim2GeneMedgenParser.loadDiseaseToGeneAssociationMapOMIM(hsGeneInfoPath, mim2geneMedgenPath);
+ * // Option 2
+ * allGeneIdToSymbolMap = GeneInfoParser.loadGeneIdToSymbolMap(homoSapiensGeneInfoFile);
+ * Multimap<TermId, GeneToAssociation> idToAssociationMap
+ *    = Mim2GeneMedgenParser.loadDiseaseToGeneAssociationMapOMIM(allGeneIdToSymbolMap, mim2geneMedgenPath);
+ *
+ * }</pre>
+ * @author Peter N Robinson
+ */
+public class Mim2GeneMedgenParser {
+  private static final String ENTREZ_GENE_PREFIX = "NCBIGene";
+  private static final String OMIM_PREFIX = "OMIM";
+
+
+  public static Multimap<TermId, GeneToAssociation>
+  loadDiseaseToGeneAssociationMapOMIM(String homoSapiensGeneInfoPath, String mim2geneMedgenPath) {
+    Map<TermId, String> geneIdToSymbolMap = GeneInfoParser.loadGeneIdToSymbolMap(homoSapiensGeneInfoPath);
+    return loadDiseaseToGeneAssociationMapOMIM(geneIdToSymbolMap, mim2geneMedgenPath);
+  }
+
+
+  /**
+   * Parse the medgen file that contains disease to gene links.
+   * https://ftp.ncbi.nih.gov/gene/DATA/mim2gene_medgen
+   *
+   * @param mim2geneMedgene Path to mim2gene_medgen file
+   * @throws IOException if the mim2gene_medgen cannot be parsed.
+   */
+  public static Multimap<TermId, GeneToAssociation>
+  loadDiseaseToGeneAssociationMapOMIM(Map<TermId, String> geneIdToSymbolMap, String mim2geneMedgene) {
+    File mim2geneMedgenFile = new File(mim2geneMedgene);
+    if (!mim2geneMedgenFile.exists()) {
+      throw new PhenolRuntimeException("Could not find mim2gene_medgen file at " + mim2geneMedgene);
+    }
+    Multimap<TermId, GeneToAssociation> associationMap = ArrayListMultimap.create();
+    try (BufferedReader br = new BufferedReader(new FileReader(mim2geneMedgenFile))) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        if (line.startsWith("#")) continue;
+        String[] associations = line.split("\t");
+        if (associations[2].equals("phenotype")) {
+          String mimid = associations[0];
+          TermId omimCurie = TermId.of(OMIM_PREFIX, mimid);
+          String entrezGeneNumber = associations[1];
+          TermId entrezId = TermId.of(ENTREZ_GENE_PREFIX, entrezGeneNumber);
+          String symbol = geneIdToSymbolMap.get(entrezId);
+          if ("-".equals(entrezGeneNumber)) {
+            continue;
+          }
+          // rarely, mim2gene has a format error and the following prevents downstream errors with null pointer
+          if (symbol == null) {
+            symbol = "-";
+          }
+          TermId geneId = TermId.of(ENTREZ_GENE_PREFIX, entrezGeneNumber);
+          Gene gene = new Gene(geneId, symbol);
+          AssociationType associationType = AssociationType.MENDELIAN;
+          if (associations[5].contains("susceptibility")) {
+            associationType = AssociationType.POLYGENIC;
+          }
+          GeneToAssociation g2a = new GeneToAssociation(gene, associationType);
+          if (!associationMap.containsEntry(omimCurie, g2a)) {
+            associationMap.put(omimCurie, g2a);
+          }
+        }
+      }
+    } catch (IOException e) {
+      String msg = String.format("Could not create gene association map: %s", e.getMessage());
+      throw new PhenolRuntimeException(msg);
+    }
+    return associationMap;
+  }
+
+
+}


### PR DESCRIPTION
I would like to disentangle some of the classes in the package with ``Gene2DiseaseAssociationParser``, it is difficult to understand what is going on and probably better to use more of a dependency injection style rather than passing paths to 4 resources and doing everything inside the class.
I added something for  mim2geneMedgen, still need to add tests.