### PR TITLE
Efficient precalculation of Resnik scores for HPO

### DIFF
--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/assoc/Gene2DiseaseAssociationParser.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/assoc/Gene2DiseaseAssociationParser.java
@@ -90,7 +90,7 @@ public class Gene2DiseaseAssociationParser {
       throw new PhenolRuntimeException("Cannot find Homo_sapiens.gene_info.gz file at \"" + homoSapiensGeneInfoFile + "\"");
     }
     if (!mim2geneMedgenFile.exists()) {
-      throw new PhenolRuntimeException("Cannot find mim2gene_medgen file at \"" + homoSapiensGeneInfoFile + "\"");
+      throw new PhenolRuntimeException("Cannot find mim2gene_medgen file at \"" + mim2geneMedgenFile + "\"");
     }
     this.allGeneIdToSymbolMap = GeneInfoParser.loadGeneIdToSymbolMap(homoSapiensGeneInfoFile);
     try {

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/assoc/Gene2DiseaseAssociationParser.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/assoc/Gene2DiseaseAssociationParser.java
@@ -87,10 +87,10 @@ public class Gene2DiseaseAssociationParser {
    */
   private void parseMim2geneAndGeneInfo(File homoSapiensGeneInfoFile, File mim2geneMedgenFile) {
     if (!homoSapiensGeneInfoFile.exists()) {
-      throw new PhenolRuntimeException("Cannot find Homo_sapiens.gene_info.gz file");
+      throw new PhenolRuntimeException("Cannot find Homo_sapiens.gene_info.gz file at \"" + homoSapiensGeneInfoFile + "\"");
     }
     if (!mim2geneMedgenFile.exists()) {
-      throw new PhenolRuntimeException("Cannot find mim2gene_medgen file");
+      throw new PhenolRuntimeException("Cannot find mim2gene_medgen file at \"" + homoSapiensGeneInfoFile + "\"");
     }
     this.allGeneIdToSymbolMap = GeneInfoParser.loadGeneIdToSymbolMap(homoSapiensGeneInfoFile);
     try {

--- a/phenol-cli/pom.xml
+++ b/phenol-cli/pom.xml
@@ -27,6 +27,12 @@
       <version>${jcommander.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+      <version>4.5.2</version>
+    </dependency>
+
     <!-- Phenol modules -->
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/Main.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/Main.java
@@ -24,6 +24,7 @@ public class Main {
   private static final String HPO_SIM = "hpo-sim";
   private static final String MONDO_DEMO = "mondo";
   private static final String MPO_ENRICH = "mpo";
+  private static final String RESNIK_GENEBASED = "resnik-gene";
 
   public static void main(String[] argv)  {
     final PrecomputeScoresOptions precomputeScoresOptions = new PrecomputeScoresOptions();
@@ -34,6 +35,7 @@ public class Main {
     final ParsingBenchmark.Options bench = new ParsingBenchmark.Options();
     final MondoDemo.Options mondo = new MondoDemo.Options();
     final PairwisePhenotypicSimilarityCalculator.Options hpo_sim = new PairwisePhenotypicSimilarityCalculator.Options();
+    final ResnikGenebasedHpoDemo.Options resnikGeneOptions = new ResnikGenebasedHpoDemo.Options();
     final JCommander jc =
         JCommander.newBuilder()
           .addCommand(PRECOMPUTE_SCORES, precomputeScoresOptions)
@@ -44,6 +46,7 @@ public class Main {
           .addCommand(HPO_SIM, hpo_sim)
           .addCommand(HP_DEMO,hpoDemo)
           .addCommand(MONDO_DEMO,mondo)
+          .addCommand(RESNIK_GENEBASED, resnikGeneOptions)
           .build();
     try {
       jc.parse(argv);
@@ -77,6 +80,8 @@ public class Main {
         new HpDemo(hpoDemo).run();
       case MONDO_DEMO:
         new MondoDemo(mondo).run();
+      case RESNIK_GENEBASED:
+        new ResnikGenebasedHpoDemo(resnikGeneOptions).run();
     }
   }
 }

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/ResnikGenebasedHpoDemo.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/ResnikGenebasedHpoDemo.java
@@ -1,0 +1,133 @@
+package org.monarchinitiative.phenol.cli.demo;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import org.monarchinitiative.phenol.annotations.assoc.HpoAssociationParser;
+import org.monarchinitiative.phenol.annotations.formats.hpo.HpoDisease;
+import org.monarchinitiative.phenol.annotations.obo.hpo.HpoDiseaseAnnotationParser;
+import org.monarchinitiative.phenol.io.OntologyLoader;
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.monarchinitiative.phenol.ontology.data.TermIds;
+import org.monarchinitiative.phenol.ontology.similarity.HpoResnikSimilarity;
+import org.monarchinitiative.phenol.ontology.similarity.ResnikSimilarity;
+
+import java.io.File;
+import java.util.*;
+
+public class ResnikGenebasedHpoDemo {
+
+  private final Ontology hpo;
+  private final Map<TermId, HpoDisease> diseaseMap;
+  /** order list of HpoDiseases taken from the above map. */
+  private List<HpoDisease> diseaseList;
+  private Map<TermId,Integer> diseaseIdToIndexMap;
+  private ResnikSimilarity resnikSimilarity;
+  private final Map<TermId, Double> termToIc;
+  private Multimap<TermId,TermId> geneToDiseaseMap;
+  private Map<TermId,String> geneIdToSymbolMap;
+  private final Map<TermId, Collection<TermId>> diseaseIdToTermIds;
+
+  public ResnikGenebasedHpoDemo(ResnikGenebasedHpoDemo.Options options) {
+    long start = System.currentTimeMillis();
+    this.hpo = OntologyLoader.loadOntology(new File(options.hpoPath));
+    long now = System.currentTimeMillis();
+    double duration = (double)(now-start)/1000.0;
+    System.out.printf("[INFO] Loaded hp.obo in %.3f seconds.\n",duration);
+    start = now;
+    List<String> databases = ImmutableList.of("OMIM"); // restrict ourselves to OMIM entries
+    this.diseaseMap = HpoDiseaseAnnotationParser.loadDiseaseMap(options.getPhenotypeDotHpoaPath(), hpo,databases);
+    now = System.currentTimeMillis();
+    duration = (double)(now-start)/1000.0;
+    System.out.printf("[INFO] Loaded phenotype.hpoa in %.3f seconds.\n",duration);
+    // Compute list of annoations and mapping from OMIM ID to term IDs.
+    start = now;
+    this.diseaseIdToTermIds = new HashMap<>();
+    final Map<TermId, Collection<TermId>> termIdToDiseaseIds = new HashMap<>();
+    for (TermId diseaseId : diseaseMap.keySet()) {
+      HpoDisease disease = diseaseMap.get(diseaseId);
+      List<TermId> hpoTerms = disease.getPhenotypicAbnormalityTermIdList();
+      diseaseIdToTermIds.putIfAbsent(diseaseId, new HashSet<>());
+      // add term anscestors
+      final Set<TermId> inclAncestorTermIds = TermIds.augmentWithAncestors(hpo, Sets.newHashSet(hpoTerms), true);
+
+      for (TermId tid : inclAncestorTermIds) {
+        termIdToDiseaseIds.putIfAbsent(tid, new HashSet<>());
+        termIdToDiseaseIds.get(tid).add(diseaseId);
+        diseaseIdToTermIds.get(diseaseId).add(tid);
+      }
+    }
+    now = System.currentTimeMillis();
+    duration = (double)(now-start)/1000.0;
+    System.out.printf("[INFO] Calculated gene-disease links in %.3f seconds.\n",duration);
+    HpoAssociationParser hpoAssociationParser = new HpoAssociationParser(options.geneInfoPath,options.mim2genMedgenPath,this.hpo);
+    this.geneToDiseaseMap = hpoAssociationParser.getGeneToDiseaseIdMap();
+    System.out.println("[INFO] geneToDiseaseMap with " + geneToDiseaseMap.size() + " entries");
+    this.geneIdToSymbolMap = hpoAssociationParser.getGeneIdToSymbolMap();
+    System.out.println("[INFO] geneIdToSymbolMap with " + geneIdToSymbolMap.size() + " entries");
+    now = System.currentTimeMillis();
+    duration = (double)(now-start)/1000.0;
+    System.out.printf("[INFO] Loaded geneInfo and mim2gebe in %.3f seconds.\n",duration);
+    TermId ROOT_HPO = TermId.of("HP:0000118");//Phenotypic abnormality
+    int totalPopulationHpoTerms = (int)  termIdToDiseaseIds.get(ROOT_HPO)
+      .stream()
+      .count();
+    termToIc = new HashMap<>();
+    for (TermId tid : termIdToDiseaseIds.keySet()) {
+      int annotatedCount = (int) termIdToDiseaseIds.get(tid)
+        .stream()
+        .count();
+      double ic = Math.log((double)annotatedCount/totalPopulationHpoTerms);
+      termToIc.put(tid, ic);
+    }
+    now = System.currentTimeMillis();
+    duration = (double)(now-start)/1000.0;
+    System.out.printf("[INFO] Calculated information content in %.3f seconds.\n",duration);
+  }
+
+  public void run() {
+    long start = System.currentTimeMillis();
+    HpoResnikSimilarity hpoResnikSimilarity = new HpoResnikSimilarity(this.hpo, this.termToIc);
+    long now = System.currentTimeMillis();
+    double duration = (double)(now-start)/1000.0;
+    System.out.printf("[INFO] Calculated pairwise Resnik similarity in %.3f seconds.\n",duration);
+    // Now check a few diagnoses
+    TermId arachnodactyly = TermId.of("HP:0000001"); // TODO
+    List<TermId> marfanFeatures = new ArrayList<>();
+    marfanFeatures.add(arachnodactyly);
+    TermId topDiseaseId = null;
+    double maxSim = 0.0;
+    for (TermId diseaseId : this.diseaseIdToTermIds.keySet()) {
+      Collection<TermId> hpoIds = this.diseaseIdToTermIds.get(diseaseId);
+
+    }
+  }
+
+
+
+  @Parameters(commandDescription = "Resnik gene-based similarity demo")
+  public static class Options {
+    @Parameter(names = {"-h"}, description = "path to hp.obo file", required = true)
+    private String hpoPath;
+    @Parameter(names="-a", description = "path to phenotype.hpoa file", required = true)
+    private String phenotypeDotHpoaPath;
+    @Parameter(names="-o",description = "output file name")
+    private String outname="pairwise_disease_similarity.tsv";
+    @Parameter(names="--geneinfo",description = "path to downloaded file ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz")
+    private String geneInfoPath;
+    @Parameter(names="--mimgene2medgen",description = "path to downloaded file from ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/mim2gene_medgen")
+    private String mim2genMedgenPath;
+    String getHpoPath() { return hpoPath; }
+
+    String getPhenotypeDotHpoaPath() {
+      return phenotypeDotHpoaPath;
+    }
+
+    String getOutname() { return outname; }
+  }
+
+
+}

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/ImmutableOntology.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/ImmutableOntology.java
@@ -164,6 +164,14 @@ public class ImmutableOntology implements Ontology {
   }
 
   @Override
+  public Set<TermId> getCommonAncestors(TermId a, TermId b) {
+    Set<TermId> ancA = getAncestorTermIds(a, false);
+    Set<TermId> ancB = getAncestorTermIds(b, false);
+    ancA.retainAll(ancB); // set intersection
+    return ancA;
+  }
+
+  @Override
   public TermId getRootTermId() {
     return rootTermId;
   }

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/ImmutableOntology.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/ImmutableOntology.java
@@ -167,9 +167,14 @@ public class ImmutableOntology implements Ontology {
   public Set<TermId> getCommonAncestors(TermId a, TermId b) {
     Set<TermId> ancA = getAncestorTermIds(a, false);
     Set<TermId> ancB = getAncestorTermIds(b, false);
-    ancA.retainAll(ancB); // set intersection
-    return ancA;
+    return Sets.intersection(ancA, ancB);
   }
+
+  @Override
+  public boolean containsTerm(TermId tid){
+    return this.termMap.containsKey(tid);
+  }
+
 
   @Override
   public TermId getRootTermId() {

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Ontology.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Ontology.java
@@ -67,6 +67,8 @@ public interface Ontology extends MinimalOntology, Serializable {
 
   Set<TermId> getCommonAncestors(TermId a, TermId b);
 
+  boolean containsTerm(TermId tid);
+
   /**
    * Return all the {@link TermId}s of all ancestors from {@code termIds}, including root.
    *

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Ontology.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Ontology.java
@@ -65,6 +65,8 @@ public interface Ontology extends MinimalOntology, Serializable {
    */
   Set<TermId> getAllAncestorTermIds(Collection<TermId> termIds, boolean includeRoot);
 
+  Set<TermId> getCommonAncestors(TermId a, TermId b);
+
   /**
    * Return all the {@link TermId}s of all ancestors from {@code termIds}, including root.
    *

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Relationship.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Relationship.java
@@ -83,4 +83,9 @@ public class Relationship {
         + relationshipType
         + "]";
   }
+
+
+  public static Relationship IS_A(TermId source, TermId target, int id) {
+    return new Relationship(source, target, id, RelationshipType.IS_A);
+  }
 }

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/similarity/HpoResnikSimilarity.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/similarity/HpoResnikSimilarity.java
@@ -1,0 +1,142 @@
+package org.monarchinitiative.phenol.ontology.similarity;
+
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+
+import java.util.*;
+
+/**
+ * Calculate pairwise similarity between HPO terms using Resnik. Offer symmetric and asymmetric similarity functions
+ * for queries against targets. (e.g., search queries against diseases).
+ * Exploit the structure of HPO to not calculate ICs for pairs of terms whose similarity must be zero because
+ * the terms are located in different parts of the Phenotypic Abnormality subhierachy (e.g., Eye and Liver).
+ * The class should be used as follows
+ * <pre>
+ *   Ontology hpo = OntologyLoader.loadOntology(new File(pathHpObo));
+ *   String geneInfoPath = "/path/to/Homo_sapiens_gene_info.gz";
+ *   String mimgeneMedgenPath = "/path/to/mim2gene_medgen";
+ *   HpoAssociationParser hpoAssociationParser = new HpoAssociationParser(geneInfoPath,mimgeneMedgenPath,hpo);
+ *   List<String> databases = ImmutableList.of("OMIM"); // restrict ourselves to OMIM entries
+ *   Map<TermId, HpoDisease> diseaseMap = HpoDiseaseAnnotationParser.loadDiseaseMap(this.pathPhenotypeHpoa, hpo,databases);
+ *   // Compute list of annotations and mapping from OMIM ID to term IDs.
+ *   final Map<TermId, Collection<TermId>> diseaseIdToTermIds = new HashMap<>();
+ *   final Map<TermId, Collection<TermId>> termIdToDiseaseIds = new HashMap<>();
+ *   for (TermId diseaseId : diseaseMap.keySet()) {
+ *     HpoDisease disease = diseaseMap.get(diseaseId);
+ *     List<TermId> hpoTerms = disease.getPhenotypicAbnormalityTermIdList();
+ *     diseaseIdToTermIds.putIfAbsent(diseaseId, new HashSet<>());
+ *     // add term anscestors
+ *     final Set<TermId> inclAncestorTermIds = TermIds.augmentWithAncestors(hpo, Sets.newHashSet(hpoTerms), true);
+ *     for (TermId tid : inclAncestorTermIds) {
+ *       termIdToDiseaseIds.putIfAbsent(tid, new HashSet<>());
+ *       termIdToDiseaseIds.get(tid).add(diseaseId);
+ *       diseaseIdToTermIds.get(diseaseId).add(tid);
+ *     }
+ *   }
+ *   // Compute information content of HPO terms, given the term-to-disease annotation.
+ *   final Map<TermId, Double> icMap = new InformationContentComputation(hpo).computeInformationContent(termIdToDiseaseIds);
+ *   HpoResnikSimilarity hrs = new HpoResnikSimilarity(hpo, icMap);
+ *   // Todo, provide methods to calculate genewise or disease with similarity.
+ *
+ *
+ * </pre>
+ * @author Peter Robinson
+ */
+public class HpoResnikSimilarity {
+
+  /** Pairwise term similarity computation. */
+  //private final PairwiseSimilarity pairwiseSimilarity;
+
+  private final Map<TermPair, Double> termPairResnikSimilarityMap;
+
+
+  public HpoResnikSimilarity(Ontology hpo, Map<TermId, Double> termToIc) {
+    //new PrecomputingPairwiseResnikSimilarity(ontology, termToIc)
+    termPairResnikSimilarityMap = new HashMap<>();
+    // Compute for relevant subontologies in HPO
+    for (TermId topTerm : toplevelTerms()) {
+      Ontology subontology = hpo.subOntology(topTerm);
+      final Set<TermId> terms = subontology.getNonObsoleteTermIds();
+      List<TermId> list = new ArrayList<>(terms);
+      for (int i = 0; i < list .size(); i++) {
+        for (int j = i + 1; j < list.size(); j++) {
+          TermId a = list.get(i);
+          TermId b = list.get(j);
+          double similarity = computeResnikSimilarity(a, b, termToIc, subontology);
+          TermPair tpair = TermPair.symmetric(a, b);
+          this.termPairResnikSimilarityMap.put(tpair, similarity);
+        }
+      }
+    }
+  }
+
+  /**
+   * Compute similarity as the information content of the Most Informative Common Ancestor (MICA)
+   * @param a The first TermId
+   * @param b The second TermId
+   * @param termToIc Map from TermId to information content of the term
+   * @param ontology Here, a subontology of the HPO
+   * @return the Resnik similarity
+   */
+  private double computeResnikSimilarity(TermId a, TermId b, Map<TermId, Double> termToIc, Ontology ontology) {
+    final Set<TermId> commonAncestors = ontology.getCommonAncestors(a, b);
+    double maxValue = 0.0;
+    for (TermId termId : commonAncestors) {
+      maxValue = Double.max(maxValue, termToIc.getOrDefault(termId, 0.0));
+    }
+    return maxValue;
+  }
+
+  /**
+   * Return the Resnik similarity between two HPO terms. Note that if we do not have a
+   * value in {@link #termPairResnikSimilarityMap}, we asssume the similarity is zero becaue
+   * the MICA of the two terms is the root.
+   * @param a The first TermId
+   * @param b The second TermId
+   * @return the Resnik similarity
+   */
+  public double getResnik(TermId a, TermId b) {
+    TermPair tpair = TermPair.symmetric(a,b);
+    return this.termPairResnikSimilarityMap.getOrDefault(tpair, 0.0);
+  }
+
+
+
+  /**
+   * List of top level terms that with a few rare exceptions which we will ignore, do
+   * not have multiple parentage relations with each other.
+   * TODO we can refactor this if we move the annotation module here.
+   * @return
+   */
+  private TermId[] toplevelTerms() {
+    TermId ABNORMAL_CELLULAR_ID = TermId.of("HP:0025354");
+    TermId BLOOD_ID = TermId.of("HP:0001871");
+    TermId CONNECTIVE_TISSUE_ID = TermId.of("HP:0003549");
+    TermId HEAD_AND_NECK_ID = TermId.of("HP:0000152");
+    TermId LIMBS_ID = TermId.of("HP:0040064");
+    TermId METABOLISM_ID = TermId.of("HP:0001939");
+    TermId PRENATAL_ID = TermId.of("HP:0001197");
+    TermId BREAST_ID = TermId.of("HP:0000769");
+    TermId CARDIOVASCULAR_ID = TermId.of("HP:0001626");
+    TermId DIGESTIVE_ID = TermId.of("HP:0025031");
+    TermId EAR_ID = TermId.of("HP:0000598");
+    TermId ENDOCRINE_ID = TermId.of("HP:0000818");
+    TermId EYE_ID = TermId.of("HP:0000478");
+    TermId GENITOURINARY_ID = TermId.of("HP:0000119");
+    TermId IMMUNOLOGY_ID = TermId.of("HP:0002715");
+    TermId INTEGUMENT_ID = TermId.of("HP:0001574");
+    TermId NERVOUS_SYSTEM_ID = TermId.of("HP:0000707");
+    TermId RESPIRATORY_ID = TermId.of("HP:0002086");
+    TermId MUSCULOSKELETAL_ID = TermId.of("HP:0033127");
+    TermId THORACIC_CAVITY_ID = TermId.of("HP:0045027");
+    TermId VOICE_ID = TermId.of("HP:0001608");
+    TermId CONSTITUTIONAL_ID = TermId.of("HP:0025142");
+    TermId GROWTH_ID = TermId.of("HP:0001507");
+    TermId NEOPLASM_ID = TermId.of("HP:0002664");
+    return new TermId[]{ABNORMAL_CELLULAR_ID, BLOOD_ID, CONNECTIVE_TISSUE_ID, HEAD_AND_NECK_ID,
+      LIMBS_ID, METABOLISM_ID, PRENATAL_ID, BREAST_ID, CARDIOVASCULAR_ID, DIGESTIVE_ID,
+      EAR_ID, ENDOCRINE_ID, EYE_ID, GENITOURINARY_ID, IMMUNOLOGY_ID, INTEGUMENT_ID,
+      NERVOUS_SYSTEM_ID, RESPIRATORY_ID, MUSCULOSKELETAL_ID, THORACIC_CAVITY_ID,
+      VOICE_ID, GROWTH_ID, CONSTITUTIONAL_ID, NEOPLASM_ID};
+  }
+}

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/similarity/HpoResnikSimilarity.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/similarity/HpoResnikSimilarity.java
@@ -102,7 +102,7 @@ public class HpoResnikSimilarity {
    * @param b The second TermId
    * @return the Resnik similarity
    */
-  public double getResnikSymmetric(TermId a, TermId b) {
+  public double getResnikTermSimilarity(TermId a, TermId b) {
     TermPair tpair = TermPair.symmetric(a,b);
     return this.termPairResnikSimilarityMap.getOrDefault(tpair, 0.0);
   }
@@ -130,7 +130,7 @@ public class HpoResnikSimilarity {
     for (TermId q : query) {
       double maxValue = 0.0;
       for (TermId t : target) {
-        maxValue = Math.max(maxValue, getResnikSymmetric(q, t));
+        maxValue = Math.max(maxValue, getResnikTermSimilarity(q, t));
       }
       sum += maxValue;
     }

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/similarity/HpoResnikSimilarity.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/similarity/HpoResnikSimilarity.java
@@ -102,9 +102,39 @@ public class HpoResnikSimilarity {
    * @param b The second TermId
    * @return the Resnik similarity
    */
-  public double getResnik(TermId a, TermId b) {
+  public double getResnikSymmetric(TermId a, TermId b) {
     TermPair tpair = TermPair.symmetric(a,b);
     return this.termPairResnikSimilarityMap.getOrDefault(tpair, 0.0);
+  }
+
+
+  public double computeScoreSymmetric(Collection<TermId> query, Collection<TermId> target) {
+    return 0.5 * (computeScoreImpl(query, target) + computeScoreImpl(target, query));
+
+  }
+
+  public double computeScoreAsymmetric(Collection<TermId> query, Collection<TermId> target) {
+    return computeScoreImpl(query, target);
+  }
+
+
+  /**
+   * Compute directed score between a query and a target set of {@link TermId}s.
+   *
+   * @param query Query set of {@link TermId}s.
+   * @param target Target set of {@link TermId}s
+   * @return Symmetric similarity score between <code>query</code> and <code>target</code>.
+   */
+  private double computeScoreImpl(Collection<TermId> query, Collection<TermId> target) {
+    double sum = 0;
+    for (TermId q : query) {
+      double maxValue = 0.0;
+      for (TermId t : target) {
+        maxValue = Math.max(maxValue, getResnikSymmetric(q, t));
+      }
+      sum += maxValue;
+    }
+    return sum / query.size();
   }
 
 

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/similarity/TermPair.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/similarity/TermPair.java
@@ -1,0 +1,54 @@
+package org.monarchinitiative.phenol.ontology.similarity;
+
+import org.monarchinitiative.phenol.ontology.data.TermId;
+
+import java.util.Objects;
+
+/**
+ * Class to represent a pair of TermId objects that we will use to index Term-pair Resnik similarities.
+ * @author Peter Robinson
+ */
+public class TermPair {
+
+  private final TermId tidA;
+  private final TermId tidB;
+
+  private TermPair(TermId a, TermId b) {
+    this.tidA = a;
+    this.tidB = b;
+  }
+
+  public TermId getTidA() {
+    return tidA;
+  }
+
+  public TermId getTidB() {
+    return tidB;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tidA, tidB);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) return false;
+    if (! (obj instanceof TermPair)) return false;
+    TermPair that = (TermPair) obj;
+    return this.tidA.equals(that.tidA) && this.tidB.equals(that.tidB);
+  }
+
+  public static TermPair symmetric(TermId a, TermId b) {
+    if (a.getId().compareTo(b.getId())>0) {
+      return new TermPair(a,b);
+    } else {
+      return new TermPair(b,a);
+    }
+  }
+
+  public static TermPair asymmetric(TermId a, TermId b) {
+    return new TermPair(a,b);
+  }
+
+}

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/similarity/HpoResnikSimilarityTest.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/similarity/HpoResnikSimilarityTest.java
@@ -37,7 +37,7 @@ public class HpoResnikSimilarityTest extends HpoOntologyTestBase {
   @Test
   public void testMicaAtRoot() {
     // These two terms have their MICA at the root, the similaroty is zero
-    double sim = similarity.getResnik(GALLOP_RHYTHM, HYPERTELORISM);
+    double sim = similarity.getResnikSymmetric(GALLOP_RHYTHM, HYPERTELORISM);
     assertEquals(0.0, sim, EPSILON);
   }
 
@@ -46,7 +46,7 @@ public class HpoResnikSimilarityTest extends HpoOntologyTestBase {
     // HYPERTELORISM - disease1
     //PROPTOSIS - disease1, disease7
     // MICA -- ABN_GLOBE_LOCATION -- disease1, disease7, frequency 2/8
-    double sim = similarity.getResnik(HYPERTELORISM, PROPTOSIS);
+    double sim = similarity.getResnikSymmetric(HYPERTELORISM, PROPTOSIS);
     double expected = -1 * Math.log(0.25);
     assertEquals(expected, sim, EPSILON);
   }
@@ -54,14 +54,14 @@ public class HpoResnikSimilarityTest extends HpoOntologyTestBase {
   @Test
   public void testHYPERTELORISM() {
     // HYPERTELORISM - disease1
-    double sim = similarity.getResnik(HYPERTELORISM, HYPERTELORISM);
+    double sim = similarity.getResnikSymmetric(HYPERTELORISM, HYPERTELORISM);
     double expected = -1 * Math.log(0.125);  // 1 in 8
     assertEquals(expected, sim, EPSILON);
   }
   @Test
   public void testIRIS_COLOBOMA() {
     // IRIS_COLOBOMA - 4 of 8 diseases
-    double sim = similarity.getResnik(IRIS_COLOBOMA, IRIS_COLOBOMA);
+    double sim = similarity.getResnikSymmetric(IRIS_COLOBOMA, IRIS_COLOBOMA);
     double expected = -1 * Math.log(0.5);  // 1 in 2
     assertEquals(expected, sim, EPSILON);
   }
@@ -70,7 +70,7 @@ public class HpoResnikSimilarityTest extends HpoOntologyTestBase {
   @Test
   public void testHEART_MURMUR() {
     // HEART_MURMUR - 3 of 8 diseases
-    double sim = similarity.getResnik(HEART_MURMUR, HEART_MURMUR);
+    double sim = similarity.getResnikSymmetric(HEART_MURMUR, HEART_MURMUR);
     double expected = -1 * Math.log(0.375);  // 1 in 2
     assertEquals(expected, sim, EPSILON);
   }
@@ -78,7 +78,7 @@ public class HpoResnikSimilarityTest extends HpoOntologyTestBase {
   @Test
   public void testHEART_MURMUR_vs_ROOT() {
     //  No term has similarity with the root
-    double sim = similarity.getResnik(HEART_MURMUR, PHENOTYPIC_ABNORMALITY);
+    double sim = similarity.getResnikSymmetric(HEART_MURMUR, PHENOTYPIC_ABNORMALITY);
     double expected = 0.0;  // 1 in 2
     assertEquals(expected, sim, EPSILON);
   }
@@ -87,14 +87,14 @@ public class HpoResnikSimilarityTest extends HpoOntologyTestBase {
     //IRIS_COLOBOMA disease 1,2,3,4
     //RETINAL_COLOBOMA disease 4, 6
     // MICA -- COLOBOMA, disease 1,2,3,4,6
-    double sim = similarity.getResnik(IRIS_COLOBOMA, RETINAL_COLOBOMA);
+    double sim = similarity.getResnikSymmetric(IRIS_COLOBOMA, RETINAL_COLOBOMA);
     double expected = -1 * Math.log(0.625);  // 1 in 2
     assertEquals(expected, sim, EPSILON);
   }
 
   @Test
   public void testSymmetric() {
-    assertEquals(similarity.getResnik(IRIS_COLOBOMA, RETINAL_COLOBOMA), similarity.getResnik(RETINAL_COLOBOMA,IRIS_COLOBOMA));
+    assertEquals(similarity.getResnikSymmetric(IRIS_COLOBOMA, RETINAL_COLOBOMA), similarity.getResnikSymmetric(RETINAL_COLOBOMA,IRIS_COLOBOMA));
   }
 
 

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/similarity/HpoResnikSimilarityTest.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/similarity/HpoResnikSimilarityTest.java
@@ -1,0 +1,103 @@
+package org.monarchinitiative.phenol.ontology.similarity;
+
+import com.google.common.collect.Sets;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.monarchinitiative.phenol.ontology.algo.InformationContentComputation;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.monarchinitiative.phenol.ontology.data.TermIds;
+import org.monarchinitiative.phenol.ontology.testdata.hpo.HpoOntologyTestBase;
+import org.monarchinitiative.phenol.ontology.testdata.hpo.ToyHpoAnnotation;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HpoResnikSimilarityTest extends HpoOntologyTestBase {
+
+  private static HpoResnikSimilarity similarity;
+
+  private static final double EPSILON = 0.0000000001;
+
+
+  @BeforeAll
+  public static void  init() {
+    final Map<TermId, Collection<TermId>> termIdToDiseaseIds = new HashMap<>();
+    for(ToyHpoAnnotation annot : hpoAnnotations) {
+      final Set<TermId> inclAncestorTermIds = TermIds.augmentWithAncestors(ontology, Sets.newHashSet(annot.getTermId()), true);
+      for (TermId tid : inclAncestorTermIds) {
+        termIdToDiseaseIds.putIfAbsent(tid, new HashSet<>());
+        termIdToDiseaseIds.get(tid).add(annot.getLabel());
+      }
+    }
+    final Map<TermId, Double> icMap = new InformationContentComputation(ontology).computeInformationContent(termIdToDiseaseIds);
+    similarity = new HpoResnikSimilarity(ontology, icMap);
+  }
+
+  @Test
+  public void testMicaAtRoot() {
+    // These two terms have their MICA at the root, the similaroty is zero
+    double sim = similarity.getResnik(GALLOP_RHYTHM, HYPERTELORISM);
+    assertEquals(0.0, sim, EPSILON);
+  }
+
+  @Test
+  public void testABN_GLOBE_LOCATION() {
+    // HYPERTELORISM - disease1
+    //PROPTOSIS - disease1, disease7
+    // MICA -- ABN_GLOBE_LOCATION -- disease1, disease7, frequency 2/8
+    double sim = similarity.getResnik(HYPERTELORISM, PROPTOSIS);
+    double expected = -1 * Math.log(0.25);
+    assertEquals(expected, sim, EPSILON);
+  }
+
+  @Test
+  public void testHYPERTELORISM() {
+    // HYPERTELORISM - disease1
+    double sim = similarity.getResnik(HYPERTELORISM, HYPERTELORISM);
+    double expected = -1 * Math.log(0.125);  // 1 in 8
+    assertEquals(expected, sim, EPSILON);
+  }
+  @Test
+  public void testIRIS_COLOBOMA() {
+    // IRIS_COLOBOMA - 4 of 8 diseases
+    double sim = similarity.getResnik(IRIS_COLOBOMA, IRIS_COLOBOMA);
+    double expected = -1 * Math.log(0.5);  // 1 in 2
+    assertEquals(expected, sim, EPSILON);
+  }
+
+  //
+  @Test
+  public void testHEART_MURMUR() {
+    // HEART_MURMUR - 3 of 8 diseases
+    double sim = similarity.getResnik(HEART_MURMUR, HEART_MURMUR);
+    double expected = -1 * Math.log(0.375);  // 1 in 2
+    assertEquals(expected, sim, EPSILON);
+  }
+
+  @Test
+  public void testHEART_MURMUR_vs_ROOT() {
+    //  No term has similarity with the root
+    double sim = similarity.getResnik(HEART_MURMUR, PHENOTYPIC_ABNORMALITY);
+    double expected = 0.0;  // 1 in 2
+    assertEquals(expected, sim, EPSILON);
+  }
+  @Test
+  public void testColobomaSim() {
+    //IRIS_COLOBOMA disease 1,2,3,4
+    //RETINAL_COLOBOMA disease 4, 6
+    // MICA -- COLOBOMA, disease 1,2,3,4,6
+    double sim = similarity.getResnik(IRIS_COLOBOMA, RETINAL_COLOBOMA);
+    double expected = -1 * Math.log(0.625);  // 1 in 2
+    assertEquals(expected, sim, EPSILON);
+  }
+
+  @Test
+  public void testSymmetric() {
+    assertEquals(similarity.getResnik(IRIS_COLOBOMA, RETINAL_COLOBOMA), similarity.getResnik(RETINAL_COLOBOMA,IRIS_COLOBOMA));
+  }
+
+
+
+
+}

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/testdata/hpo/HpoOntologyTestBase.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/testdata/hpo/HpoOntologyTestBase.java
@@ -1,0 +1,126 @@
+package org.monarchinitiative.phenol.ontology.testdata.hpo;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Lists;
+import org.monarchinitiative.phenol.ontology.data.*;
+
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class HpoOntologyTestBase {
+  protected static final Ontology ontology;
+  protected static final TermId PHENOTYPIC_ABNORMALITY = TermId.of("HP:0000118"); //
+  // Heart
+  protected static final TermId CARDIOVASCULAR_ID = TermId.of("HP:0001626");
+  protected static final TermId ABN_CARDIOVASCULAR_PHYSIOLOGY = TermId.of("HP:0011025");
+  protected static final TermId ABN_HEART_SOUND =  TermId.of("HP:0031657");
+  protected static final TermId HEART_MURMUR =  TermId.of("HP:0030148");
+  protected static final TermId GALLOP_RHYTHM =  TermId.of("HP:0033113");
+  protected static final TermId SYNCOPE =  TermId.of("HP:0001279");
+  protected static final TermId VASOVAGAL_SYNCOPE =  TermId.of("HP:0012668");
+  protected static final TermId ORTHOSTATIC_SYNCOPE =  TermId.of("HP:0012670");
+  // EYE
+  protected static final TermId EYE_ID = TermId.of("HP:0000478");
+  protected static final TermId ABN_EYE_MORPHOLOGY = TermId.of("HP:0012372");
+  protected static final TermId COLOBOMA = TermId.of("HP:0000589");
+  protected static final TermId RETINAL_COLOBOMA = TermId.of("HP:0000480");
+  protected static final TermId IRIS_COLOBOMA = TermId.of("HP:0000612");
+  protected static final TermId ABN_GLOBE_LOCATION = TermId.of("HP:0100886");
+  protected static final TermId PROPTOSIS = TermId.of("HP:0000520");
+  protected static final TermId HYPERTELORISM = TermId.of("HP:0000316");
+
+  protected static final ImmutableMap.Builder<TermId, Term> termMapBuilder = ImmutableMap.builder();
+
+  protected static final ImmutableMap.Builder<Integer, Relationship> relationMapBuilder = ImmutableMap.builder();
+
+  protected static final List<ToyHpoAnnotation> hpoAnnotations;
+
+  protected static final AtomicInteger counter = new AtomicInteger(0);
+
+  static {
+    termMapBuilder.put(createTerm(PHENOTYPIC_ABNORMALITY, "Phenotypic abnormality"));
+    termMapBuilder.put(createTerm(CARDIOVASCULAR_ID, "Abnormality of the cardiovascular system"));
+    termMapBuilder.put(createTerm(ABN_CARDIOVASCULAR_PHYSIOLOGY,"Abnormal cardiovascular system physiology"));
+    termMapBuilder.put(createTerm(ABN_HEART_SOUND, "Abnormal heart sound"));
+    termMapBuilder.put(createTerm(HEART_MURMUR, "Heart murmur"));
+    termMapBuilder.put(createTerm(GALLOP_RHYTHM, "Gallop rhythm"));
+    termMapBuilder.put(createTerm(SYNCOPE, "Syncope"));
+    termMapBuilder.put(createTerm(VASOVAGAL_SYNCOPE, "Vasovagal syncope"));
+    termMapBuilder.put(createTerm(ORTHOSTATIC_SYNCOPE, "Orthostatic syncope"));
+    termMapBuilder.put(createTerm(EYE_ID, "Abnormality of the eye"));
+    termMapBuilder.put(createTerm(ABN_EYE_MORPHOLOGY, "Abnormal eye morphology"));
+    termMapBuilder.put(createTerm(COLOBOMA, "Coloboma"));
+    termMapBuilder.put(createTerm(RETINAL_COLOBOMA, "Retinal coloboma"));
+    termMapBuilder.put(createTerm(IRIS_COLOBOMA, "Iris coloboma"));
+    termMapBuilder.put(createTerm(ABN_GLOBE_LOCATION, "Abnormality of globe location"));
+    termMapBuilder.put(createTerm(PROPTOSIS, "Proptosis"));
+    termMapBuilder.put(createTerm(HYPERTELORISM, "Hypertelorism"));
+    ImmutableMap<TermId, Term> termMap = termMapBuilder.build();
+
+    relationMapBuilder.put(createRelationship(CARDIOVASCULAR_ID, PHENOTYPIC_ABNORMALITY));
+    relationMapBuilder.put(createRelationship(ABN_CARDIOVASCULAR_PHYSIOLOGY, CARDIOVASCULAR_ID));
+    relationMapBuilder.put(createRelationship(ABN_HEART_SOUND, ABN_CARDIOVASCULAR_PHYSIOLOGY));
+    relationMapBuilder.put(createRelationship(HEART_MURMUR,ABN_HEART_SOUND));
+    relationMapBuilder.put(createRelationship(GALLOP_RHYTHM,ABN_HEART_SOUND));
+    relationMapBuilder.put(createRelationship(SYNCOPE, ABN_CARDIOVASCULAR_PHYSIOLOGY));
+    relationMapBuilder.put(createRelationship(VASOVAGAL_SYNCOPE, SYNCOPE));
+    relationMapBuilder.put(createRelationship(ORTHOSTATIC_SYNCOPE, SYNCOPE));
+    // Eye
+    relationMapBuilder.put(createRelationship(EYE_ID, PHENOTYPIC_ABNORMALITY));
+    relationMapBuilder.put(createRelationship(ABN_EYE_MORPHOLOGY, EYE_ID));
+    relationMapBuilder.put(createRelationship(COLOBOMA, ABN_EYE_MORPHOLOGY));
+    relationMapBuilder.put(createRelationship(RETINAL_COLOBOMA, COLOBOMA));
+    relationMapBuilder.put(createRelationship(IRIS_COLOBOMA, COLOBOMA));
+    relationMapBuilder.put(createRelationship(ABN_GLOBE_LOCATION, ABN_EYE_MORPHOLOGY));
+    relationMapBuilder.put(createRelationship(PROPTOSIS, ABN_GLOBE_LOCATION));
+    relationMapBuilder.put(createRelationship(HYPERTELORISM, ABN_GLOBE_LOCATION));
+
+    ImmutableMap<Integer, Relationship> relationMap = relationMapBuilder.build();
+
+    ontology = ImmutableOntology.builder()
+      .metaInfo(ImmutableSortedMap.of())
+      .terms(termMap.values())
+      .relationships(relationMap.values())
+      .build();
+
+    hpoAnnotations =
+      Lists.newArrayList(
+        new ToyHpoAnnotation(IRIS_COLOBOMA, "disease1"),
+        new ToyHpoAnnotation(IRIS_COLOBOMA, "disease2"),
+        new ToyHpoAnnotation(IRIS_COLOBOMA, "disease3"),
+        new ToyHpoAnnotation(IRIS_COLOBOMA, "disease4"),
+        new ToyHpoAnnotation(RETINAL_COLOBOMA, "disease4"),
+        new ToyHpoAnnotation(RETINAL_COLOBOMA, "disease6"),
+        new ToyHpoAnnotation(HYPERTELORISM, "disease1"),
+        new ToyHpoAnnotation(PROPTOSIS, "disease1"),
+        new ToyHpoAnnotation(PROPTOSIS, "disease7"),
+        new ToyHpoAnnotation(ORTHOSTATIC_SYNCOPE, "disease8"),
+        new ToyHpoAnnotation(GALLOP_RHYTHM, "disease1"),
+        new ToyHpoAnnotation(HEART_MURMUR, "disease2"),
+        new ToyHpoAnnotation(HEART_MURMUR, "disease5"),
+        new ToyHpoAnnotation(HEART_MURMUR, "disease7"));
+
+  }
+
+
+
+  private static Map.Entry<Integer, Relationship> createRelationship(TermId source, TermId target) {
+    int id = counter.incrementAndGet();
+    return new AbstractMap.SimpleEntry<>(id, Relationship.IS_A(source, target,id));
+  }
+
+
+  private static Map.Entry<TermId, Term> createTerm(TermId tid, String label) {
+    final String definition = "n/a";
+    Term t = Term.builder()
+        .id(tid)
+        .name(label)
+        .definition(definition)
+        .build();
+    return new AbstractMap.SimpleEntry<>(tid,t);
+  }
+
+}

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/testdata/hpo/HpoOntologyTestBase.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/testdata/hpo/HpoOntologyTestBase.java
@@ -32,15 +32,16 @@ public class HpoOntologyTestBase {
   protected static final TermId PROPTOSIS = TermId.of("HP:0000520");
   protected static final TermId HYPERTELORISM = TermId.of("HP:0000316");
 
-  protected static final ImmutableMap.Builder<TermId, Term> termMapBuilder = ImmutableMap.builder();
-
-  protected static final ImmutableMap.Builder<Integer, Relationship> relationMapBuilder = ImmutableMap.builder();
-
   protected static final List<ToyHpoAnnotation> hpoAnnotations;
 
-  protected static final AtomicInteger counter = new AtomicInteger(0);
+  protected static final List<TermId> disease1annotations;
+  protected static final List<TermId> disease2annotations;
+
+  private static final AtomicInteger counter = new AtomicInteger(0);
 
   static {
+    final ImmutableMap.Builder<TermId, Term> termMapBuilder = ImmutableMap.builder();
+    final ImmutableMap.Builder<Integer, Relationship> relationMapBuilder = ImmutableMap.builder();
     termMapBuilder.put(createTerm(PHENOTYPIC_ABNORMALITY, "Phenotypic abnormality"));
     termMapBuilder.put(createTerm(CARDIOVASCULAR_ID, "Abnormality of the cardiovascular system"));
     termMapBuilder.put(createTerm(ABN_CARDIOVASCULAR_PHYSIOLOGY,"Abnormal cardiovascular system physiology"));
@@ -102,6 +103,9 @@ public class HpoOntologyTestBase {
         new ToyHpoAnnotation(HEART_MURMUR, "disease2"),
         new ToyHpoAnnotation(HEART_MURMUR, "disease5"),
         new ToyHpoAnnotation(HEART_MURMUR, "disease7"));
+
+    disease1annotations = Lists.newArrayList(IRIS_COLOBOMA, HYPERTELORISM, PROPTOSIS, GALLOP_RHYTHM);
+    disease2annotations = Lists.newArrayList(IRIS_COLOBOMA, HEART_MURMUR);
 
   }
 

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/testdata/hpo/ToyHpoAnnotation.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/testdata/hpo/ToyHpoAnnotation.java
@@ -1,0 +1,48 @@
+package org.monarchinitiative.phenol.ontology.testdata.hpo;
+
+import com.google.common.collect.ComparisonChain;
+import org.monarchinitiative.phenol.ontology.data.TermAnnotation;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+
+import javax.annotation.Nonnull;
+
+public class ToyHpoAnnotation implements TermAnnotation {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TermId termId;
+    private final TermId label;
+
+  public ToyHpoAnnotation(TermId termId, String label) {
+      this.termId = termId;
+      this.label = TermId.of("VEG", label);
+    }
+
+    @Override
+    public TermId getTermId() {
+      return termId;
+    }
+
+    @Override
+    public TermId getLabel() {
+      return label;
+    }
+
+    @Override
+    public int compareTo(@Nonnull TermAnnotation o) {
+      if (!(o instanceof ToyHpoAnnotation)) {
+        throw new RuntimeException("Cannot compare " + o + " to " + this);
+      }
+      ToyHpoAnnotation that = (ToyHpoAnnotation) o;
+
+      return ComparisonChain.start()
+        .compare(this.termId, that.termId)
+        .compare(this.label, that.label)
+        .result();
+    }
+
+    @Override
+    public String toString() {
+      return "VegetableTermAnnotation [termId=" + termId + ", label=" + label + "]";
+    }
+}


### PR DESCRIPTION
Hi! This is the proposed HpoResnik calculator -- it should be much more efficient than the current version. I will be writing some tests. Everything would be easier if we merge the annotations and the core branches. I forget why we separated them, I think we were worried about code bloat/efficiency, but all of our usages pretty much always need both branches, and I think there is more advantage to merging the two modules. Thoughts? If nobody has any objections, I would merge the two branches for the next release. The main new thing for the next release will be the better way of doing Resnik simialrity for HPO.