### PR TITLE
Add `release` metadatum entry.

### DIFF
--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obographs/OboGraphDocumentAdaptor.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obographs/OboGraphDocumentAdaptor.java
@@ -135,9 +135,9 @@ public class OboGraphDocumentAdaptor {
       metaMap.put("data-version", version);
       if (meta.getBasicPropertyValues() != null) {
         for (BasicPropertyValue basicPropertyValue : meta.getBasicPropertyValues()) {
-          if (basicPropertyValue.getPred().equalsIgnoreCase("date")) {
-            String date = basicPropertyValue.getVal().trim();
-            metaMap.put("date", date);
+          if (basicPropertyValue.getPred().contains("#versionInfo")) {
+            String release = basicPropertyValue.getVal().trim();
+            metaMap.put("release", release);
           }
         }
       }

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderGoTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderGoTest.java
@@ -17,6 +17,8 @@ import java.io.InputStream;
 import java.nio.file.Paths;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.*;
 
 
@@ -58,10 +60,9 @@ public class OntologyLoaderGoTest {
    * @throws FileNotFoundException if the test GO file cannot be found
    * @throws PhenolException upon parse errors
    */
-  @Disabled
   @Test
   public void testReal() throws Exception {
-    String localpath = "src/test/resources/go.obo";
+    String localpath = "src/test/resources/go/go_head.json";
     String RO_PREFIX = "RO";
     Ontology goOntology = OntologyLoader.loadOntology(Paths.get(localpath).toFile(), "GO");
     assertNotNull(goOntology);
@@ -80,4 +81,12 @@ public class OntologyLoaderGoTest {
       }
     }
   }
+
+  @Test
+  public void testMetadata() {
+    Map<String, String> metaInfo = ontology.getMetaInfo();
+    assertThat(metaInfo, hasEntry("release", "2017-06-16"));
+    assertThat(metaInfo, hasEntry("data-version", "http://purl.obolibrary.org/obo/go/releases/2017-06-16/go.owl"));
+  }
+
 }

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderHpoTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderHpoTest.java
@@ -19,8 +19,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.monarchinitiative.phenol.ontology.data.TermSynonymScope.EXACT;
 
@@ -37,6 +36,13 @@ public class OntologyLoaderHpoTest {
   public void testParseHpoToy() {
     final DefaultDirectedGraph<TermId, IdLabeledEdge> graph = hpo.getGraph();
     assertNotNull(graph);
+  }
+
+  @Test
+  public void testMetadata() {
+    Map<String, String> metaInfo = hpo.getMetaInfo();
+    assertThat(metaInfo, hasEntry("release", "2021-06-08"));
+    assertThat(metaInfo, hasEntry("data-version", "http://purl.obolibrary.org/obo/hp/releases/2021-06-08/hp.json"));
   }
 
   @Test

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderMondoTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderMondoTest.java
@@ -6,7 +6,10 @@ import org.monarchinitiative.phenol.ontology.data.*;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -48,5 +51,12 @@ public class OntologyLoaderMondoTest {
     assertEquals(TermId.of("OMIM:155000"), xref.id());
   }
 
+  @Test
+  public void testMetadata() {
+    Map<String, String> metaInfo = mondo.getMetaInfo();
+    System.err.println(metaInfo);
+    assertThat(metaInfo, hasEntry("release", "2020-01-27"));
+    assertThat(metaInfo, hasEntry("data-version", "http://purl.obolibrary.org/obo/mondo/releases/2020-01-27/reasoned.owl.owl/mondo.owl"));
+  }
 
 }

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderMpoTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderMpoTest.java
@@ -104,6 +104,7 @@ public class OntologyLoaderMpoTest {
 
     assertEquals(3, graph.edgeSet().size());
     assertEquals(TermId.of("MP:0000001"), ontology.getRootTermId());
-    assertEquals(Map.of("data-version","http://purl.obolibrary.org/obo/mp/releases/2017-06-05/mp.owl"), ontology.getMetaInfo());
+    assertEquals(Map.of("data-version","http://purl.obolibrary.org/obo/mp/releases/2017-06-05/mp.owl",
+      "release", "2017-06-05"), ontology.getMetaInfo());
   }
 }

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obographs/OboGraphDocumentAdaptorTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/obographs/OboGraphDocumentAdaptorTest.java
@@ -254,7 +254,7 @@ public class OboGraphDocumentAdaptorTest {
     Relationship paRootRel = new Relationship(paTerm.id(), rootTerm.id(), 2, RelationshipType.IS_A);
 
     assertEquals(List.of(moiRootRel, paRootRel), instance.getRelationships());
-    assertEquals(Map.of("data-version", "releases/2018-10-09"), instance.getMetaInfo());
+    assertEquals(Map.of("data-version", "releases/2018-10-09", "release", "2018-10-09"), instance.getMetaInfo());
 
     Ontology hpoOntology = instance.buildOntology();
     assertEquals(TermId.of("HP:0000001"), hpoOntology.getRootTermId());


### PR DESCRIPTION
Hi @pnrobinson , @julesjacobsen ,

I was having troubles with getting `Ontology` release version.

There are these `meta` lines in `hp.json` and it looks like the last predicate is what I am looking for:
```json
"meta": {
        "basicPropertyValues": [
          {
            "pred": "http://purl.obolibrary.org/obo/IAO_0000700",
            "val": "http://purl.obolibrary.org/obo/HP_0000001"
          },
          {
            "pred": "http://purl.org/dc/elements/1.1/creator",
            "val": "Human Phenotype Ontology Consortium"
          },
          {
            "pred": "http://purl.org/dc/elements/1.1/creator",
            "val": "Monarch Initiative"
          },
          {
            "pred": "http://purl.org/dc/elements/1.1/creator",
            "val": "Peter Robinson"
          },
          {
            "pred": "http://purl.org/dc/elements/1.1/creator",
            "val": "Sebastian Köhler"
          },
          {
            "pred": "http://purl.org/dc/elements/1.1/description",
            "val": "The Human Phenotype Ontology (HPO) provides a standardized vocabulary of phenotypic abnormalities and clinical features encountered in human disease."
          },
          {
            "pred": "http://purl.org/dc/elements/1.1/rights",
            "val": "Peter Robinson, Sebastian Koehler, The Human Phenotype Ontology Consortium, and The Monarch Initiative"
          },
          {
            "pred": "http://purl.org/dc/elements/1.1/subject",
            "val": "Phenotypic abnormalities encountered in human disease"
          },
          {
            "pred": "http://purl.org/dc/elements/1.1/title",
            "val": "Human Phenotype Ontology"
          },
          {
            "pred": "http://purl.org/dc/terms/license",
            "val": "https://hpo.jax.org/app/license"
          },
          {
            "pred": "http://www.geneontology.org/formats/oboInOwl#default-namespace",
            "val": "human_phenotype"
          },
          {
            "pred": "http://www.geneontology.org/formats/oboInOwl#logical-definition-view-relation",
            "val": "has_part"
          },
          {
            "pred": "http://www.geneontology.org/formats/oboInOwl#saved-by",
            "val": "Peter Robinson, Sebastian Koehler, Sandra Doelken, Chris Mungall, Melissa Haendel, Nicole Vasilevsky, Monarch Initiative, et al."
          },
          {
            "pred": "http://www.w3.org/2000/01/rdf-schema#comment",
            "val": "Please see license of HPO at http://www.human-phenotype-ontology.org"
          },
          {
            "pred": "http://www.w3.org/2002/07/owl#versionInfo",
            "val": "2022-02-14"
          }
        ],
        "subsets": [],
        "version": "http://purl.obolibrary.org/obo/hp/releases/2022-02-14/hp.json",
        "xrefs": []
      }
```

However, there is just a single entry in the `Ontology.getMetaInfo()` after parsing the JSON:
```
version=http://purl.obolibrary.org/obo/hp/releases/2022-02-14/hp.json
```

So, I'm thinking about adding the code in this PR to create a `release=2022-02-14` entry.

I don't know if the business with searching for `#versionInfo` is general enough to work with ontologies other than HPO.

Do you think this would work out?