### PR TITLE
Salvage v1 API

### DIFF
--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoAnnotation.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoAnnotation.java
@@ -15,7 +15,9 @@ import java.util.Optional;
  *
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  * @version 0.1.3 (2018-03-12)
+ * @deprecated to be removed in v3.0.0, use {@link HpoDiseaseAnnotation} instead.
  */
+@Deprecated(forRemoval = true, since = "2.0.0-RC2")
 public class HpoAnnotation implements Identified {
   /**
    * The annotated {@link TermId}.

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDisease.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDisease.java
@@ -6,6 +6,7 @@ import org.monarchinitiative.phenol.ontology.data.Identified;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -23,19 +24,27 @@ import java.util.stream.StreamSupport;
  */
 public interface HpoDisease extends Identified {
 
-  static HpoDisease of(String name,
-                       TermId databaseId,
+  static HpoDisease of(TermId diseaseId,
+                       String name,
                        TemporalInterval globalOnset,
                        List<HpoDiseaseAnnotation> phenotypicAbnormalities,
                        List<TermId> modesOfInheritance) {
-    return new HpoDiseaseDefault(databaseId, name, globalOnset, phenotypicAbnormalities, modesOfInheritance);
+    return new HpoDiseaseDefault(diseaseId, name, globalOnset, phenotypicAbnormalities, modesOfInheritance);
   }
 
   /**
-   * @deprecated use {@link #id()} instead.
+   * @deprecated to be removed in v3.0.0, use {@link #id()} instead.
    */
   @Deprecated(since = "2.0.0-RC2", forRemoval = true)
   default TermId diseaseDatabaseTermId() {
+    return id();
+  }
+
+  /**
+   * @deprecated to be removed in v3.0.0, use {@link #id()} instead.
+   */
+  @Deprecated(since = "2.0.0-RC2", forRemoval = true)
+  default TermId getDiseaseDatabaseTermId() {
     return id();
   }
 
@@ -43,7 +52,7 @@ public interface HpoDisease extends Identified {
   String diseaseName();
 
   /**
-   * @deprecated use {@link #diseaseName()} instead.
+   * @deprecated to be removed in v3.0.0, use {@link #diseaseName()} instead.
    */
   @Deprecated(since = "2.0.0-RC2", forRemoval = true)
   default String getName() {
@@ -51,7 +60,7 @@ public interface HpoDisease extends Identified {
   }
 
   /**
-   * @deprecated use {@link #diseaseName()} instead.
+   * @deprecated to be removed in v3.0.0, use {@link #diseaseName()} instead.
    */
   @Deprecated(since = "2.0.0-RC2", forRemoval = true)
   default String getDiseaseName() {
@@ -65,17 +74,54 @@ public interface HpoDisease extends Identified {
 
   List<TermId> modesOfInheritance();
 
+  /**
+   * @deprecated to be removed in v3.0.0, use {@link #modesOfInheritance()} instead.
+   */
+  @Deprecated(forRemoval = true, since = "2.0.0-RC2")
+  default List<TermId> getModesOfInheritance() {
+    return modesOfInheritance();
+  }
+
+  /**
+   * @return iterator of <em>ALL</em> phenotypic abnormalities of the disease, both present and absent.
+   */
   Iterator<HpoDiseaseAnnotation> phenotypicAbnormalities();
 
   int phenotypicAbnormalitiesCount();
 
+  /**
+   * @return stream of <em>ALL</em> phenotypic abnormalities of the disease, both present and absent.
+   */
   default Stream<HpoDiseaseAnnotation> phenotypicAbnormalitiesStream() {
     return StreamSupport.stream(Spliterators.spliterator(phenotypicAbnormalities(), phenotypicAbnormalitiesCount(), Spliterator.DISTINCT & Spliterator.SIZED), false);
   }
 
+  /**
+   * @return stream of absent phenotypic abnormalities of the disease,
+   * i.e. ones that were observed in <em>zero</em> out of <em>n</em> affected individuals.
+   */
+  default Stream<HpoDiseaseAnnotation> absentPhenotypicAbnormalitiesStream() {
+    return phenotypicAbnormalitiesStream()
+      .filter(a -> a.ratio().map(Ratio::isZero).orElse(false));
+  }
+
+  /**
+   *
+   * @deprecated to be removed in v3.0.0, use {@link #absentPhenotypicAbnormalitiesStream()} instead.
+   */
   @Deprecated(since = "2.0.0-RC2", forRemoval = true)
   default List<TermId> negativeAnnotations() {
-    return List.of();
+    return absentPhenotypicAbnormalitiesStream()
+      .map(HpoDiseaseAnnotation::id)
+      .collect(Collectors.toList());
+  }
+
+  /**
+   * @deprecated to be removed in v3.0.0, use {@link #absentPhenotypicAbnormalitiesStream()} instead.
+   */
+  @Deprecated(since = "2.0.0-RC2", forRemoval = true)
+  default List<TermId> getNegativeAnnotations() {
+    return negativeAnnotations();
   }
 
   /**
@@ -103,7 +149,24 @@ public interface HpoDisease extends Identified {
       .flatMap(HpoDiseaseAnnotation::ratio);
   }
 
+  /**
+   * @deprecated use {@link #getPhenotypicAbnormalityTermIds()} and decide if you really need the list.
+   */
+  @Deprecated(since = "2.0.0-RC2", forRemoval = true)
+  default List<TermId> getPhenotypicAbnormalityTermIdList() {
+    return getPhenotypicAbnormalityTermIds().collect(Collectors.toList());
+  }
+
+  /**
+   * @deprecated use {@link #phenotypicAbnormalityTermIds()}.
+   */
+  @Deprecated(since = "2.0.0-RC2", forRemoval = true)
   default Stream<TermId> getPhenotypicAbnormalityTermIds() {
+    return phenotypicAbnormalityTermIds();
+  }
+
+
+  default Stream<TermId> phenotypicAbnormalityTermIds() {
     return phenotypicAbnormalitiesStream()
       .map(HpoDiseaseAnnotation::id);
   }

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseAnnotation.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseAnnotation.java
@@ -47,6 +47,10 @@ public interface HpoDiseaseAnnotation extends Identified, Comparable<HpoDiseaseA
    */
   Optional<Ratio> ratio();
 
+  default Optional<Float> frequency() {
+    return ratio().map(Ratio::frequency);
+  }
+
   /**
    * @return list of {@link TemporalInterval}s representing periods when the {@link HpoDiseaseAnnotation} is observable.
    */

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderDefault.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderDefault.java
@@ -46,8 +46,13 @@ class HpoDiseaseLoaderDefault implements HpoDiseaseLoader {
     this.databasePrefixes = options.includedDatabases().stream()
       .map(DiseaseDatabase::prefix)
       .collect(Collectors.toUnmodifiableSet());
-    this.clinicalCourseSubHierarchy = hpo.subOntology(HpoClinicalModifierTermIds.CLINICAL_COURSE).getNonObsoleteTermIds();
-    this.inheritanceSubHierarchy = hpo.subOntology(HpoModeOfInheritanceTermIds.INHERITANCE_ROOT).getNonObsoleteTermIds();
+
+    this.clinicalCourseSubHierarchy = hpo.containsTerm(HpoClinicalModifierTermIds.CLINICAL_COURSE)
+      ? hpo.subOntology(HpoClinicalModifierTermIds.CLINICAL_COURSE).getNonObsoleteTermIds()
+      : Set.of();
+    this.inheritanceSubHierarchy = hpo.containsTerm(HpoModeOfInheritanceTermIds.INHERITANCE_ROOT)
+      ? hpo.subOntology(HpoModeOfInheritanceTermIds.INHERITANCE_ROOT).getNonObsoleteTermIds()
+      : Set.of();
   }
 
   @Override
@@ -106,8 +111,7 @@ class HpoDiseaseLoaderDefault implements HpoDiseaseLoader {
       .map(entry -> toDiseaseAnnotation(entry.getKey(), entry.getValue()))
       .collect(Collectors.toUnmodifiableList());
 
-    return Optional.of(HpoDisease.of(diseaseData.diseaseName(),
-      diseaseId,
+    return Optional.of(HpoDisease.of(diseaseId, diseaseData.diseaseName(),
       onset,
       diseaseAnnotations,
       Collections.unmodifiableList(diseaseData.modesOfInheritance())));

--- a/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/HpoDiseaseExamples.java
+++ b/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/HpoDiseaseExamples.java
@@ -2,7 +2,6 @@ package org.monarchinitiative.phenol.annotations;
 
 import org.monarchinitiative.phenol.annotations.base.Ratio;
 import org.monarchinitiative.phenol.annotations.base.temporal.TemporalInterval;
-import org.monarchinitiative.phenol.annotations.base.temporal.Age;
 import org.monarchinitiative.phenol.annotations.formats.hpo.*;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -32,12 +31,11 @@ public class HpoDiseaseExamples {
     );
     List<TermId> modesOfInheritance = List.of(TermId.of("HP:0000006")); // Autosomal dominant inheritance
 
-    return HpoDisease.of(
+    return HpoDisease.of(databaseId,
       diseaseName,
-      databaseId,
       TemporalInterval.openEnd(HpoOnset.YOUNG_ADULT_ONSET.start()),
       annotations,
       modesOfInheritance
-      );
+    );
   }
 }


### PR DESCRIPTION
I removed some methods from `phenol-annotations` while the methods could have been deprecated instead. This is an attempt to minimize headaches resulting from compile-time errors when switching from v1 to v2.