### PR TITLE
Implement `HpoDiseaseAnnotation.isAbsent()`.

### DIFF
--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseAnnotation.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseAnnotation.java
@@ -52,6 +52,15 @@ public interface HpoDiseaseAnnotation extends Identified, Comparable<HpoDiseaseA
   }
 
   /**
+   * @return {@code true} if the annotation was not observed in the disease (the numerator of {@link #ratio()} is zero).
+   * In absence of {@link #ratio()}, the method defaults to {@code false}.
+   */
+  default boolean isAbsent() {
+    return ratio().map(Ratio::isZero)
+      .orElse(false);
+  }
+
+  /**
    * @return list of {@link TemporalInterval}s representing periods when the {@link HpoDiseaseAnnotation} is observable.
    */
   List<TemporalInterval> observationIntervals();

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseAnnotation.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseAnnotation.java
@@ -52,8 +52,10 @@ public interface HpoDiseaseAnnotation extends Identified, Comparable<HpoDiseaseA
   }
 
   /**
-   * @return {@code true} if the annotation was not observed in the disease (the numerator of {@link #ratio()} is zero).
-   * In absence of {@link #ratio()}, the method defaults to {@code false}.
+   * @return {@code true} if the phenotypic feature in question was annotated to be absent in the disease
+   * (meaning that the numerator of {@link #ratio()} is zero, because an annotation such as <em>0/k</em> exists
+   * that represents a study in which zero of <em>k</em> study participants were observed not to have the HPO term
+   * in question).
    */
   default boolean isAbsent() {
     return ratio().map(Ratio::isZero)


### PR DESCRIPTION
Implement `isAbsent()` method for `HpoDiseaseAnnotation` that returns `true` if the annotation was not observed in the disease (the numerator of `ratio()` is zero). The method defaults to `false` in absence of `ratio()`.

Closes #379 .