### PR TITLE
Provide `Iterable` over `HpoDiseaseAnnotation`s instead of an `Iterator`.

### DIFF
--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/analysis/HpoOnsetDistributionSimple.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/analysis/HpoOnsetDistributionSimple.java
@@ -5,8 +5,6 @@ import org.monarchinitiative.phenol.annotations.base.temporal.TemporalInterval;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoDisease;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoDiseaseAnnotation;
 
-import java.util.Iterator;
-
 public class HpoOnsetDistributionSimple implements HpoOnsetDistribution {
 
   static HpoOnsetDistributionSimple of() {
@@ -18,9 +16,7 @@ public class HpoOnsetDistributionSimple implements HpoOnsetDistribution {
 
   @Override
   public boolean isObservableInAge(HpoDisease disease, TemporalInterval interval) {
-    for (Iterator<HpoDiseaseAnnotation> iterator = disease.phenotypicAbnormalities(); iterator.hasNext(); ) {
-      HpoDiseaseAnnotation annotation = iterator.next();
-
+    for (HpoDiseaseAnnotation annotation : disease.annotations()) {
       boolean isObservable = annotation.observedInInterval(interval)
         .map(Ratio::isPositive)
         .orElse(false);

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/assoc/HpoAssociationLoader.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/assoc/HpoAssociationLoader.java
@@ -36,6 +36,7 @@ public class HpoAssociationLoader {
 
   /**
    * @deprecated to be removed in v3.0.0, use {@link HpoAssociationDataBuilder} instead.
+   * @see HpoAssociationData#builder(Ontology)
    */
   @Deprecated(forRemoval = true)
   public static HpoAssociationData loadHpoAssociationData(Ontology hpo,
@@ -75,8 +76,8 @@ public class HpoAssociationLoader {
                                                                                Map<TermId, Collection<GeneToAssociation>> diseaseToGeneMap) {
     Map<TermId, Collection<TermId>> phenotypeToDisease = new HashMap<>();
     for (HpoDisease disease : diseases) {
-      for (Iterator<HpoDiseaseAnnotation> iterator = disease.phenotypicAbnormalities(); iterator.hasNext(); ) {
-        TermId hpoId = iterator.next().id();
+      for (HpoDiseaseAnnotation annotation : disease.annotations()) {
+        TermId hpoId = annotation.id();
         phenotypeToDisease.computeIfAbsent(hpoId, k -> new HashSet<>())
           .add(disease.id());
       }

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoAssociationDataBuilder.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoAssociationDataBuilder.java
@@ -163,8 +163,8 @@ public class HpoAssociationDataBuilder {
                                                            Map<TermId, Collection<GeneToAssociation>> diseaseToGeneMap) {
     Map<TermId, Collection<TermId>> phenotypeToDisease = new HashMap<>();
     for (HpoDisease disease : diseases) {
-      for (Iterator<HpoDiseaseAnnotation> iterator = disease.phenotypicAbnormalities(); iterator.hasNext(); ) {
-        TermId hpoId = iterator.next().id();
+      for (HpoDiseaseAnnotation annotation: disease.annotations()) {
+        TermId hpoId = annotation.id();
         phenotypeToDisease.computeIfAbsent(hpoId, k -> new HashSet<>())
           .add(disease.id());
       }

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDisease.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDisease.java
@@ -85,15 +85,44 @@ public interface HpoDisease extends Identified {
   }
 
   /**
-   * @return iterator of <em>ALL</em> phenotypic abnormalities of the disease, both present and absent.
+   * @return iterable over <em>ALL</em> disease annotations, both present and absent.
    */
-  Iterator<HpoDiseaseAnnotation> phenotypicAbnormalities();
+  Iterable<HpoDiseaseAnnotation> annotations();
 
-  int phenotypicAbnormalitiesCount();
+  /**
+   * @return number of annotations present in the disease.
+   */
+  int annotationCount();
+
+  /**
+   * @return stream of <em>ALL</em> disease annotations, both present and absent.
+   */
+  default Stream<HpoDiseaseAnnotation> annotationStream() {
+    return StreamSupport.stream(annotations().spliterator(), false);
+  }
+
+  /**
+   * @return iterator of <em>ALL</em> phenotypic abnormalities of the disease, both present and absent.
+   * @deprecated to be removed in v2.0.0, use {@link #annotations()} instead.
+   */
+  @Deprecated(forRemoval = true)
+  default Iterator<HpoDiseaseAnnotation> phenotypicAbnormalities() {
+    return annotations().iterator();
+  }
+
+  /**
+   * @deprecated to be removed in v2.0.0, use {@link #annotationCount()} instead.
+   */
+  @Deprecated(forRemoval = true)
+  default int phenotypicAbnormalitiesCount() {
+    return annotationCount();
+  }
 
   /**
    * @return stream of <em>ALL</em> phenotypic abnormalities of the disease, both present and absent.
+   * @deprecated to be removed in 2.0.0, use {@link #annotationTermIds()}
    */
+  @Deprecated(forRemoval = true)
   default Stream<HpoDiseaseAnnotation> phenotypicAbnormalitiesStream() {
     return StreamSupport.stream(Spliterators.spliterator(phenotypicAbnormalities(), phenotypicAbnormalitiesCount(), Spliterator.DISTINCT & Spliterator.SIZED), false);
   }
@@ -101,7 +130,7 @@ public interface HpoDisease extends Identified {
   /**
    * The method is kept for backward compatibility. However, the method throws {@link PhenolRuntimeException} upon each invocation.
    *
-   * @deprecated to be removed in 2.0.0, use {@link #phenotypicAbnormalities()} or {@link #phenotypicAbnormalitiesStream()} instead.
+   * @deprecated to be removed in 2.0.0, use {@link #annotations()} or {@link #annotationStream()} instead.
    * @throws PhenolRuntimeException upon each invocation.
    */
   @Deprecated(forRemoval = true, since = "2.0.0-RC2")
@@ -110,27 +139,27 @@ public interface HpoDisease extends Identified {
   }
 
   /**
-   * @return stream of absent phenotypic abnormalities of the disease,
+   * @return stream of absent disease annotations,
    * i.e. ones that were observed in <em>zero</em> out of <em>n</em> affected individuals.
    */
-  default Stream<HpoDiseaseAnnotation> absentPhenotypicAbnormalitiesStream() {
+  default Stream<HpoDiseaseAnnotation> absentAnnotationsStream() {
     return phenotypicAbnormalitiesStream()
       .filter(a -> a.ratio().map(Ratio::isZero).orElse(false));
   }
 
   /**
    *
-   * @deprecated to be removed in v3.0.0, use {@link #absentPhenotypicAbnormalitiesStream()} instead.
+   * @deprecated to be removed in v3.0.0, use {@link #absentAnnotationsStream()} instead.
    */
   @Deprecated(since = "2.0.0-RC2", forRemoval = true)
   default List<TermId> negativeAnnotations() {
-    return absentPhenotypicAbnormalitiesStream()
+    return absentAnnotationsStream()
       .map(Identified::id)
       .collect(Collectors.toList());
   }
 
   /**
-   * @deprecated to be removed in v3.0.0, use {@link #absentPhenotypicAbnormalitiesStream()} instead.
+   * @deprecated to be removed in v3.0.0, use {@link #absentAnnotationsStream()} instead.
    */
   @Deprecated(since = "2.0.0-RC2", forRemoval = true)
   default List<TermId> getNegativeAnnotations() {
@@ -167,30 +196,41 @@ public interface HpoDisease extends Identified {
    */
   @Deprecated(since = "2.0.0-RC2", forRemoval = true)
   default List<TermId> getPhenotypicAbnormalityTermIdList() {
-    return getPhenotypicAbnormalityTermIds().collect(Collectors.toList());
+    return getPhenotypicAbnormalityTermIds()
+      .collect(Collectors.toList());
   }
 
   /**
-   * @deprecated use {@link #phenotypicAbnormalityTermIds()}.
+   * @deprecated use {@link #annotationTermIds()}.
    */
   @Deprecated(since = "2.0.0-RC2", forRemoval = true)
   default Stream<TermId> getPhenotypicAbnormalityTermIds() {
-    return phenotypicAbnormalityTermIds();
+    return annotationTermIds();
   }
 
-
-  default Stream<TermId> phenotypicAbnormalityTermIds() {
-    return phenotypicAbnormalitiesStream()
+  /**
+   * @return stream of disease annotation IDs.
+   */
+  default Stream<TermId> annotationTermIds() {
+    return annotationStream()
       .map(Identified::id);
   }
 
   /**
+   * @return a list of disease annotation IDs.
+   */
+  default List<TermId> annotationTermIdList() {
+    return annotationTermIds()
+      .collect(Collectors.toList());
+  }
+
+  /**
    * @return the count of the non-negated annotations excluding mode of inheritance
-   * @deprecated use {@link #phenotypicAbnormalitiesCount()}
+   * @deprecated use {@link #annotationCount()}
    */
   @Deprecated(since = "2.0.0-RC2", forRemoval = true)
   default long getNumberOfPhenotypeAnnotations() {
-    return phenotypicAbnormalitiesCount();
+    return annotationCount();
   }
 
   /**

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseDefault.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseDefault.java
@@ -64,16 +64,13 @@ class HpoDiseaseDefault implements HpoDisease {
     return modesOfInheritance;
   }
 
-  /**
-   * @return The list of frequency-annotated phenotypic abnormalities.
-   */
   @Override
-  public Iterator<HpoDiseaseAnnotation> phenotypicAbnormalities() {
-    return phenotypicAbnormalities.iterator();
+  public Iterable<HpoDiseaseAnnotation> annotations() {
+    return phenotypicAbnormalities;
   }
 
   @Override
-  public int phenotypicAbnormalitiesCount() {
+  public int annotationCount() {
     return phenotypicAbnormalities.size();
   }
 

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationAlgorithms.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationAlgorithms.java
@@ -31,8 +31,7 @@ public class HpoAnnotationAlgorithms {
                                                                  boolean propagate) {
     Map<TermId,Integer> annotationCounts = new HashMap<>();
     for (HpoDisease disease : diseaseSet) {
-      Set<TermId> termset = disease.phenotypicAbnormalitiesStream()
-        .map(Identified::id)
+      Set<TermId> termset = disease.annotationTermIds()
         .collect(Collectors.toSet());
       if (propagate) {
         termset.addAll(getAncestorTerms(ontology,termset,false));

--- a/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/io/hpo/AggregatedHpoDiseaseLoaderTest.java
+++ b/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/io/hpo/AggregatedHpoDiseaseLoaderTest.java
@@ -61,7 +61,7 @@ public class AggregatedHpoDiseaseLoaderTest {
 
     HpoDisease omimSyndrome = omimSyndromeOptional.get();
 
-    List<HpoDiseaseAnnotation> annotations = omimSyndrome.phenotypicAbnormalitiesStream()
+    List<HpoDiseaseAnnotation> annotations = omimSyndrome.annotationStream()
       .sorted()
       .collect(Collectors.toList());
 

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/PairwisePhenotypicSimilarityCalculator.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/PairwisePhenotypicSimilarityCalculator.java
@@ -2,7 +2,6 @@ package org.monarchinitiative.phenol.cli.demo;
 
 import org.monarchinitiative.phenol.annotations.assoc.GeneInfoGeneType;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoAssociationData;
-import org.monarchinitiative.phenol.annotations.assoc.HpoAssociationLoader;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoDisease;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoDiseases;
 import org.monarchinitiative.phenol.annotations.io.hpo.HpoDiseaseLoader;
@@ -203,7 +202,7 @@ public class PairwisePhenotypicSimilarityCalculator {
    * of phenotypic similarity of the diseases to which the genes are annotated.
    */
   private void performGeneBasedAnalysis() throws IOException {
-    HpoDiseases diseases = HpoDiseaseLoader.of(hpo).load(pathPhenotypeHpoa);
+    HpoDiseases diseases = HpoDiseaseLoaders.defaultLoader(hpo, HpoDiseaseLoaderOptions.defaultOptions()).load(pathPhenotypeHpoa);
     HpoAssociationData hpoAssociationData = HpoAssociationData.builder(hpo)
       .homoSapiensGeneInfo(geneInfoPath, GeneInfoGeneType.DEFAULT)
       .mim2GeneMedgen(mimgeneMedgenPath)
@@ -341,7 +340,7 @@ public class PairwisePhenotypicSimilarityCalculator {
 
     for (TermId diseaseId : diseaseMap.keySet()) {
       HpoDisease disease = diseaseMap.get(diseaseId);
-      List<TermId> hpoTerms = disease.phenotypicAbnormalityTermIds().collect(Collectors.toList());
+      List<TermId> hpoTerms = disease.annotationTermIds().collect(Collectors.toList());
       diseaseIdToTermIds.putIfAbsent(diseaseId, new HashSet<>());
       // add term ancestors
       final Set<TermId> inclAncestorTermIds = TermIds.augmentWithAncestors(hpo, new HashSet<>(hpoTerms), true);
@@ -388,8 +387,8 @@ public class PairwisePhenotypicSimilarityCalculator {
       for (int j=i;j<n_diseases;j++) {
         HpoDisease d1 = diseaseList.get(i);
         HpoDisease d2 = diseaseList.get(j);
-        List<TermId> pheno1 = d1.phenotypicAbnormalityTermIds().collect(Collectors.toList());
-        List<TermId> pheno2 = d2.phenotypicAbnormalityTermIds().collect(Collectors.toList());
+        List<TermId> pheno1 = d1.annotationTermIds().collect(Collectors.toList());
+        List<TermId> pheno2 = d2.annotationTermIds().collect(Collectors.toList());
         double similarity = resnikSimilarity.computeScore(pheno1, pheno2);
         similarityScores[i][j]=similarity;
         similarityScores[j][i]=similarity; // symmetric

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/ResnikGeneBasedHpoDemo.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/ResnikGeneBasedHpoDemo.java
@@ -52,7 +52,7 @@ public class ResnikGeneBasedHpoDemo {
     this.diseaseIdToTermIds = new HashMap<>();
     final Map<TermId, Collection<TermId>> termIdToDiseaseIds = new HashMap<>();
     for (HpoDisease disease:hpoDiseases) {
-      List<TermId> hpoTerms = disease.getPhenotypicAbnormalityTermIds().collect(Collectors.toList());
+      List<TermId> hpoTerms = disease.annotationTermIdList();
 
       // add term ancestors
       Set<TermId> inclAncestorTermIds = TermIds.augmentWithAncestors(hpo, new HashSet<>(hpoTerms), true);


### PR DESCRIPTION
Provide `Iterable<HpoDiseaseAnnotation>` in `HpoDisease` so that the following constructs are possible:

```java
HpoDisease disease = ...
for (HpoDiseaseAnnotation annotation: disease.annotations()) {
  // process the annotation
}
```

I think we do not necessarily need a `List<HpoDiseaseAnnotation>` nor a `Set<HpoDiseaseAnnotation>`. `Iterable<HpoDiseaseAnnotation>` should be enough.

Closes #376 