### PR TITLE
Ratio and frequency are non-null in `HpoDiseaseAnnotation`.

### DIFF
--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDisease.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDisease.java
@@ -144,7 +144,7 @@ public interface HpoDisease extends Identified {
    */
   default Stream<HpoDiseaseAnnotation> absentAnnotationsStream() {
     return phenotypicAbnormalitiesStream()
-      .filter(a -> a.ratio().map(Ratio::isZero).orElse(false));
+      .filter(a -> a.ratio().isZero());
   }
 
   /**
@@ -188,7 +188,7 @@ public interface HpoDisease extends Identified {
     return phenotypicAbnormalitiesStream()
       .filter(diseaseAnnotation -> diseaseAnnotation.id().equals(termId))
       .findFirst()
-      .flatMap(HpoDiseaseAnnotation::ratio);
+      .map(HpoDiseaseAnnotation::ratio);
   }
 
   /**
@@ -243,7 +243,7 @@ public interface HpoDisease extends Identified {
    */
   default boolean isAnnotatedTo(TermId termId, Ontology hpo) {
     List<TermId> directAnnotations = phenotypicAbnormalitiesStream()
-      .filter(a -> !a.isAbsent())
+      .filter(HpoDiseaseAnnotation::isPresent)
       .map(Identified::id)
       .collect(Collectors.toList());
     Set<TermId> ancestors = hpo.getAllAncestorTermIds(directAnnotations, true);

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseAnnotation.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseAnnotation.java
@@ -48,13 +48,16 @@ public interface HpoDiseaseAnnotation extends Identified, Comparable<HpoDiseaseA
   Stream<HpoDiseaseAnnotationMetadata> metadata();
 
   /**
-   * @return ratio representing number of individuals with this {@link HpoDiseaseAnnotation} or an empty optional
-   * if no occurrence data is available.
+   * @return ratio representing number of individuals with this {@link HpoDiseaseAnnotation}.
    */
-  Optional<Ratio> ratio();
+  Ratio ratio();
 
-  default Optional<Float> frequency() {
-    return ratio().map(Ratio::frequency);
+  /**
+   * @return frequency of this {@link HpoDiseaseAnnotation} in the cohort of individuals used to assert
+   * the presence of the annotation in an {@link HpoDisease}.
+   */
+  default float frequency() {
+    return ratio().frequency();
   }
 
   /**
@@ -64,9 +67,17 @@ public interface HpoDiseaseAnnotation extends Identified, Comparable<HpoDiseaseA
    * in question).
    */
   default boolean isAbsent() {
-    return ratio().map(Ratio::isZero)
-      .orElse(false);
+    return ratio().isZero();
   }
+
+  /**
+   * @return the opposite of what {@link #isAbsent()} returns.
+   * @see #isAbsent()
+   */
+  default boolean isPresent() {
+    return !isAbsent();
+  }
+
 
   /**
    * @return list of {@link TemporalInterval}s representing periods when the {@link HpoDiseaseAnnotation} is observable.

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseAnnotationDefault.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseAnnotationDefault.java
@@ -82,7 +82,7 @@ class HpoDiseaseAnnotationDefault implements HpoDiseaseAnnotation {
                                       List<TemporalInterval> observationIntervals) {
     this.termId = Objects.requireNonNull(termId, "Term ID must not be null");
     this.metadata = metadata;
-    this.ratio = ratio; // nullable
+    this.ratio = Objects.requireNonNull(ratio, "Ratio must not be null!");
     this.observationIntervals = observationIntervals;
   }
 
@@ -97,8 +97,8 @@ class HpoDiseaseAnnotationDefault implements HpoDiseaseAnnotation {
   }
 
   @Override
-  public Optional<Ratio> ratio() {
-    return Optional.ofNullable(ratio);
+  public Ratio ratio() {
+    return ratio;
   }
 
   @Override

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/AggregatedHpoDiseaseAnnotation.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/AggregatedHpoDiseaseAnnotation.java
@@ -46,8 +46,8 @@ class AggregatedHpoDiseaseAnnotation implements HpoDiseaseAnnotation {
   }
 
   @Override
-  public Optional<Ratio> ratio() {
-    return Optional.ofNullable(ratio);
+  public Ratio ratio() {
+    return ratio;
   }
 
   @Override

--- a/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseAnnotationTest.java
+++ b/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseAnnotationTest.java
@@ -45,10 +45,7 @@ public class HpoDiseaseAnnotationTest {
 
     @Test
     public void ratio() {
-      Optional<Ratio> ratioOptional = instance.ratio();
-
-      assertThat(ratioOptional.isPresent(), equalTo(true));
-      Ratio ratio = ratioOptional.get();
+      Ratio ratio = instance.ratio();
       assertThat(ratio.numerator(), equalTo(15));
       assertThat(ratio.denominator(), equalTo(50));
     }

--- a/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/io/hpo/AggregatedHpoDiseaseLoaderTest.java
+++ b/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/io/hpo/AggregatedHpoDiseaseLoaderTest.java
@@ -68,7 +68,7 @@ public class AggregatedHpoDiseaseLoaderTest {
     assertThat(annotations, hasSize(3));
     HpoDiseaseAnnotation first = annotations.get(0);
     assertThat(first.id().getValue(), equalTo("HP:0001167"));
-    assertThat(first.ratio().get(), equalTo(Ratio.of(1, 8)));
+    assertThat(first.ratio(), equalTo(Ratio.of(1, 8)));
     assertThat(first.references(), hasSize(1));
     assertThat(first.references(), hasItem(AnnotationReference.of(TermId.of("PMID:20375004"), EvidenceCode.PCS)));
     assertThat(first.earliestOnset().get(), equalTo(Age.postnatal(1, 0, 0)));
@@ -76,7 +76,7 @@ public class AggregatedHpoDiseaseLoaderTest {
 
     HpoDiseaseAnnotation second = annotations.get(1);
     assertThat(second.id().getValue(), equalTo("HP:0001167"));
-    assertThat(second.ratio().get(), equalTo(Ratio.of(4, 5)));
+    assertThat(second.ratio(), equalTo(Ratio.of(4, 5)));
     assertThat(second.references(), hasSize(1));
     assertThat(second.references(), hasItem(AnnotationReference.of(TermId.of("PMID:22736615"), EvidenceCode.PCS)));
     assertThat(second.earliestOnset().get(), equalTo(Age.postnatal(29)));
@@ -84,7 +84,7 @@ public class AggregatedHpoDiseaseLoaderTest {
 
     HpoDiseaseAnnotation third = annotations.get(2);
     assertThat(third.id().getValue(), equalTo("HP:0001238"));
-    assertThat(third.ratio().get(), equalTo(Ratio.of(0, 50)));
+    assertThat(third.ratio(), equalTo(Ratio.of(0, 50)));
     assertThat(third.references(), hasSize(1));
     assertThat(third.references(), hasItem(AnnotationReference.of(TermId.of("PMID:20375004"), EvidenceCode.PCS)));
     assertThat(third.earliestOnset().isEmpty(), equalTo(true));


### PR DESCRIPTION
Fixes #388 