### PR TITLE
Implement `equals` and `hashCode` on XRefs

### DIFF
--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Dbxref.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Dbxref.java
@@ -1,6 +1,7 @@
 package org.monarchinitiative.phenol.ontology.data;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Implementation of immutable {@link Dbxref}s.
@@ -45,6 +46,19 @@ public class Dbxref {
 
   public Map<String, String> getTrailingModifiers() {
     return trailingModifiers;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Dbxref dbxref = (Dbxref) o;
+    return Objects.equals(name, dbxref.name) && Objects.equals(description, dbxref.description) && Objects.equals(trailingModifiers, dbxref.trailingModifiers);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, description, trailingModifiers);
   }
 
   @Override

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/SimpleXref.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/SimpleXref.java
@@ -1,5 +1,7 @@
 package org.monarchinitiative.phenol.ontology.data;
 
+import java.util.Objects;
+
 /**
  * Class to represent the database_cross_reference such as "PMID:102212" or "HPO:skoehler" that
  * is used to represent the provenance of the Term definitions in the HPO.
@@ -116,6 +118,19 @@ public class SimpleXref {
    */
   public String getId() {
     return id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SimpleXref that = (SimpleXref) o;
+    return prefix == that.prefix && Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(prefix, id);
   }
 
   @Override

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/TermXref.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/TermXref.java
@@ -1,5 +1,7 @@
 package org.monarchinitiative.phenol.ontology.data;
 
+import java.util.Objects;
+
 /**
  * Immutable implementation of {@link TermXref}.
  *
@@ -34,6 +36,19 @@ public class TermXref implements Identified {
 
   public String getDescription() {
     return description;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TermXref termXref = (TermXref) o;
+    return Objects.equals(id, termXref.id) && Objects.equals(description, termXref.description);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, description);
   }
 
   @Override


### PR DESCRIPTION
Implement `equals` and `hashCode` on XRef classes to allow value-based comparison.