### PR TITLE
Move HPO constants to annotations module.

### DIFF
--- a/phenol-annotations/src/main/java/module-info.java
+++ b/phenol-annotations/src/main/java/module-info.java
@@ -10,6 +10,8 @@ module org.monarchinitiative.phenol.annotations {
   exports org.monarchinitiative.phenol.annotations.base;
   exports org.monarchinitiative.phenol.annotations.base.temporal;
 
+  exports org.monarchinitiative.phenol.annotations.constants.hpo;
+
   exports org.monarchinitiative.phenol.annotations.formats;
   exports org.monarchinitiative.phenol.annotations.formats.go;
   exports org.monarchinitiative.phenol.annotations.formats.hpo;

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/constants/hpo/HpoClinicalModifierTermIds.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/constants/hpo/HpoClinicalModifierTermIds.java
@@ -1,4 +1,4 @@
-package org.monarchinitiative.phenol.constants.hpo;
+package org.monarchinitiative.phenol.annotations.constants.hpo;
 
 import org.monarchinitiative.phenol.ontology.data.TermId;
 

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/constants/hpo/HpoFrequencyTermIds.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/constants/hpo/HpoFrequencyTermIds.java
@@ -1,4 +1,4 @@
-package org.monarchinitiative.phenol.constants.hpo;
+package org.monarchinitiative.phenol.annotations.constants.hpo;
 
 import org.monarchinitiative.phenol.ontology.data.TermId;
 

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/constants/hpo/HpoModeOfInheritanceTermIds.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/constants/hpo/HpoModeOfInheritanceTermIds.java
@@ -1,4 +1,4 @@
-package org.monarchinitiative.phenol.constants.hpo;
+package org.monarchinitiative.phenol.annotations.constants.hpo;
 
 import org.monarchinitiative.phenol.ontology.data.TermId;
 

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/constants/hpo/HpoOnsetTermIds.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/constants/hpo/HpoOnsetTermIds.java
@@ -1,4 +1,4 @@
-package org.monarchinitiative.phenol.constants.hpo;
+package org.monarchinitiative.phenol.annotations.constants.hpo;
 
 import org.monarchinitiative.phenol.ontology.data.TermId;
 

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/constants/hpo/HpoSubOntologyRootTermIds.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/constants/hpo/HpoSubOntologyRootTermIds.java
@@ -1,4 +1,4 @@
-package org.monarchinitiative.phenol.constants.hpo;
+package org.monarchinitiative.phenol.annotations.constants.hpo;
 
 import org.monarchinitiative.phenol.ontology.data.TermId;
 

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/constants/hpo/package-info.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/constants/hpo/package-info.java
@@ -1,4 +1,4 @@
 /**
  * The package contains top-level terms from Human Phenotype Ontology.
  */
-package org.monarchinitiative.phenol.constants.hpo;
+package org.monarchinitiative.phenol.annotations.constants.hpo;

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoFrequency.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoFrequency.java
@@ -1,6 +1,7 @@
 package org.monarchinitiative.phenol.annotations.formats.hpo;
 
 import org.monarchinitiative.phenol.annotations.base.Ratio;
+import org.monarchinitiative.phenol.annotations.constants.hpo.HpoFrequencyTermIds;
 import org.monarchinitiative.phenol.ontology.data.Identified;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -14,24 +15,24 @@ import org.monarchinitiative.phenol.ontology.data.TermId;
  * <b>Note:</b> we assume a cohort of 50 subjects was used to determine the feature of the frequency.
  * As such, the {@link #denominator()} value is always equal to <code>50</code>.
  *
- * @see org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds
+ * @see HpoFrequencyTermIds
  * @author <a href="mailto:manuel.holtgrewe@bihealth.de">Manuel Holtgrewe</a>
  * @author <a href="mailto:sebastian.koehler@charite.de">Sebastian Koehler</a>
  */
 public enum HpoFrequency implements Identified, Ratio {
 
   /** Always present (100% of the cases). */
-  OBLIGATE(org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds.OBLIGATE, "Obligate", 50),
+  OBLIGATE(HpoFrequencyTermIds.OBLIGATE, "Obligate", 50),
   /** Very frequent (80-99% of the cases). */
-  VERY_FREQUENT(org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds.VERY_FREQUENT, "Very frequent", 45),
+  VERY_FREQUENT(HpoFrequencyTermIds.VERY_FREQUENT, "Very frequent", 45),
   /** Frequent (30-79% of the cases). */
-  FREQUENT(org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds.FREQUENT, "Frequent", 27),
+  FREQUENT(HpoFrequencyTermIds.FREQUENT, "Frequent", 27),
   /** Occasional (5-29% of the cases). */
-  OCCASIONAL(org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds.OCCASIONAL, "Occasional", 20),
+  OCCASIONAL(HpoFrequencyTermIds.OCCASIONAL, "Occasional", 20),
   /** Very rare (1-4% of the cases). */
-  VERY_RARE(org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds.VERY_RARE, "Very rare", 2),
+  VERY_RARE(HpoFrequencyTermIds.VERY_RARE, "Very rare", 2),
   /** Excluded (0% of the cases). */
-  EXCLUDED(org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds.EXCLUDED, "Excluded", 0);
+  EXCLUDED(HpoFrequencyTermIds.EXCLUDED, "Excluded", 0);
 
   private final TermId termId;
   private final String label;
@@ -44,7 +45,7 @@ public enum HpoFrequency implements Identified, Ratio {
   }
 
   /**
-   * Return the {@link TermId} that corresponds to this HpoFrequency. The default is {@link org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds#OBLIGATE}.
+   * Return the {@link TermId} that corresponds to this HpoFrequency. The default is {@link HpoFrequencyTermIds#OBLIGATE}.
    *
    * @return Corresponding {@link TermId} in the HPO of {@code this} frequency category.
    * @deprecated use {@link #id()} instead

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoFrequencyTermIds.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoFrequencyTermIds.java
@@ -8,28 +8,28 @@ import org.monarchinitiative.phenol.ontology.data.TermId;
  * @see HpoFrequency
  * @author <a href="mailto:manuel.holtgrewe@bihealth.de">Manuel Holtgrewe</a>
  * @author <a href="mailto:sebastian.koehler@charite.de">Sebastian Koehler</a>
- * @deprecated the class will be removed in <code>v3.0.0</code>, use {@link org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds} instead.
+ * @deprecated the class will be removed in <code>v3.0.0</code>, use {@link org.monarchinitiative.phenol.annotations.constants.hpo.HpoFrequencyTermIds} instead.
  */
 @Deprecated(forRemoval = true, since = "2.0.0-RC2")
 public final class HpoFrequencyTermIds {
 
   /** {@link TermId} for "always present (100% of the cases)". */
-  public static final TermId OBLIGATE = org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds.OBLIGATE;
+  public static final TermId OBLIGATE = org.monarchinitiative.phenol.annotations.constants.hpo.HpoFrequencyTermIds.OBLIGATE;
 
   /** {@link TermId} for "very frequent (80-99% of the cases)". */
-  public static final TermId VERY_FREQUENT = org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds.VERY_FREQUENT;
+  public static final TermId VERY_FREQUENT = org.monarchinitiative.phenol.annotations.constants.hpo.HpoFrequencyTermIds.VERY_FREQUENT;
 
   /** {@link TermId} for "frequent (30-79% of the cases)". */
-  public static final TermId FREQUENT = org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds.FREQUENT;
+  public static final TermId FREQUENT = org.monarchinitiative.phenol.annotations.constants.hpo.HpoFrequencyTermIds.FREQUENT;
 
   /** {@link TermId} for "occasional (5-29% of the cases)". */
-  public static final TermId OCCASIONAL = org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds.OCCASIONAL;
+  public static final TermId OCCASIONAL = org.monarchinitiative.phenol.annotations.constants.hpo.HpoFrequencyTermIds.OCCASIONAL;
 
   /** {@link TermId} for "excluded (1-4% of the cases)". */
-  public static final TermId VERY_RARE = org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds.VERY_RARE;
+  public static final TermId VERY_RARE = org.monarchinitiative.phenol.annotations.constants.hpo.HpoFrequencyTermIds.VERY_RARE;
 
   /** {@link TermId} for "excluded (0% of the cases)". */
-  public static final TermId EXCLUDED = org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds.EXCLUDED;
+  public static final TermId EXCLUDED = org.monarchinitiative.phenol.annotations.constants.hpo.HpoFrequencyTermIds.EXCLUDED;
 
   private HpoFrequencyTermIds() {}
 }

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoModeOfInheritanceTermIds.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoModeOfInheritanceTermIds.java
@@ -8,98 +8,98 @@ import org.monarchinitiative.phenol.ontology.data.TermId;
  * @author <a href="mailto:manuel.holtgrewe@bihealth.de">Manuel Holtgrewe</a>
  * @author <a href="mailto:sebastian.koehler@charite.de">Sebastian Koehler</a>
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
- * @deprecated the class will be removed in <code>v3.0.0</code>, use {@link org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds} instead.
+ * @deprecated the class will be removed in <code>v3.0.0</code>, use {@link org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds} instead.
  */
 @Deprecated(forRemoval = true, since = "2.0.0-RC2")
 public final class HpoModeOfInheritanceTermIds {
 
-  public static final TermId INHERITANCE_ROOT = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.INHERITANCE_ROOT;
+  public static final TermId INHERITANCE_ROOT = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.INHERITANCE_ROOT;
 
   /** {@link TermId} for term "heterogeneous"/"genetic heterogeneity". */
-  public static final TermId HETEROGENEOUS = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.HETEROGENEOUS;
+  public static final TermId HETEROGENEOUS = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.HETEROGENEOUS;
 
   /** {@link TermId} for term "multifactorial inheritance". */
-  public static final TermId MULTIFACTORIAL = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.MULTIFACTORIAL;
+  public static final TermId MULTIFACTORIAL = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.MULTIFACTORIAL;
 
   /** {@link TermId} for term "polygenic inheritance". */
-  public static final TermId POLYGENIC = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.POLYGENIC;
+  public static final TermId POLYGENIC = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.POLYGENIC;
 
   /** {@link TermId} for term "oligogenic inheritance". */
-  public static final TermId OLIGOGENIC = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.OLIGOGENIC;
+  public static final TermId OLIGOGENIC = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.OLIGOGENIC;
 
   /** {@link TermId} for term "digenic inheritance". */
-  public static final TermId DIGENIC = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.DIGENIC;
+  public static final TermId DIGENIC = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.DIGENIC;
 
   /** {@link TermId} for term "mitochondrial inheritance". */
-  public static final TermId MITOCHONDRIAL = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.MITOCHONDRIAL;
+  public static final TermId MITOCHONDRIAL = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.MITOCHONDRIAL;
 
   /** {@link TermId} for "somatic mutation". */
-  public static final TermId SOMATIC_MUTATION = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.SOMATIC_MUTATION;
+  public static final TermId SOMATIC_MUTATION = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.SOMATIC_MUTATION;
 
   /** {@link TermId} for "somatic mosaicism". */
-  public static final TermId SOMATIC_MOSAICISM = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.SOMATIC_MOSAICISM;
+  public static final TermId SOMATIC_MOSAICISM = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.SOMATIC_MOSAICISM;
 
   /** {@link TermId} for "contiguous gene syndrom". */
-  public static final TermId CONTIGUOUS_GENE_SYNDROME = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.CONTIGUOUS_GENE_SYNDROME;
+  public static final TermId CONTIGUOUS_GENE_SYNDROME = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.CONTIGUOUS_GENE_SYNDROME;
 
   /**
    * {@link TermId} for "autosomal dominant contiguous gene syndrom.
    *
    * @see #AUTOSOMAL_DOMINANT_CONTIGUOUS_GENE_SYNDROME
    */
-  public static final TermId CONTIGUOUS_GENE_SYNDROME_AUTOSOMAL_DOMINANT = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.CONTIGUOUS_GENE_SYNDROME_AUTOSOMAL_DOMINANT;
+  public static final TermId CONTIGUOUS_GENE_SYNDROME_AUTOSOMAL_DOMINANT = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.CONTIGUOUS_GENE_SYNDROME_AUTOSOMAL_DOMINANT;
 
   /** {@link TermId} for "familial predisposition". */
-  public static final TermId FAMILIAL_PREDISPOSITION = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.FAMILIAL_PREDISPOSITION;
+  public static final TermId FAMILIAL_PREDISPOSITION = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.FAMILIAL_PREDISPOSITION;
 
   /** {@link TermId} for "genetic anticipation". */
-  public static final TermId GENETIC_ANTICIPATION = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.GENETIC_ANTICIPATION;
+  public static final TermId GENETIC_ANTICIPATION = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.GENETIC_ANTICIPATION;
 
   /** {@link TermId} for "genetic anticipation with paternal bias". */
-  public static final TermId GENETIC_ANTICIPATION_PATERNAL_BIAS = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.GENETIC_ANTICIPATION_PATERNAL_BIAS;
+  public static final TermId GENETIC_ANTICIPATION_PATERNAL_BIAS = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.GENETIC_ANTICIPATION_PATERNAL_BIAS;
 
   /** {@link TermId} for "sporadic"/"isolated cases". */
-  public static final TermId SPORADIC = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.SPORADIC;
+  public static final TermId SPORADIC = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.SPORADIC;
 
   /** {@link TermId} for "gonosomal inheritance". */
-  public static final TermId GONOSOMAL = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.GONOSOMAL;
+  public static final TermId GONOSOMAL = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.GONOSOMAL;
 
   /** {@link TermId} for "X-linked inheritance". */
-  public static final TermId X_LINKED = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.X_LINKED;
+  public static final TermId X_LINKED = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.X_LINKED;
 
   /** {@link TermId} for "X-linked dominant inheritance. */
-  public static final TermId X_LINKED_DOMINANT = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.X_LINKED_DOMINANT;
+  public static final TermId X_LINKED_DOMINANT = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.X_LINKED_DOMINANT;
 
   /** {@link TermId} for "X-linked recessive inheritance. */
-  public static final TermId X_LINKED_RECESSIVE = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.X_LINKED_RECESSIVE;
+  public static final TermId X_LINKED_RECESSIVE = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.X_LINKED_RECESSIVE;
 
   /** {@link TermId} for "Y-linked inheritance. */
-  public static final TermId Y_LINKED = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.Y_LINKED;
+  public static final TermId Y_LINKED = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.Y_LINKED;
   /** {@link TermId} for "autosomal recessive inheritance. */
-  public static final TermId AUTOSOMAL_RECESSIVE = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_RECESSIVE;
+  public static final TermId AUTOSOMAL_RECESSIVE = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_RECESSIVE;
   /** {@link TermId} for "autosomal dominant inheritance. */
-  public static final TermId AUTOSOMAL_DOMINANT = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT;
+  public static final TermId AUTOSOMAL_DOMINANT = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT;
 
   /** {@link TermId} for "autosomal dominant inheritance with paternal imprinting". */
-  public static final TermId AUTOSOMAL_DOMINANT_PATERNAL_IMPRINTING = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT_PATERNAL_IMPRINTING;
+  public static final TermId AUTOSOMAL_DOMINANT_PATERNAL_IMPRINTING = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT_PATERNAL_IMPRINTING;
 
   /** {@link TermId} for "autosomal dominant inheritance with maternal imprinting". */
-  public static final TermId AUTOSOMAL_DOMINANT_MATERNAL_IMPRINTING = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT_MATERNAL_IMPRINTING;
+  public static final TermId AUTOSOMAL_DOMINANT_MATERNAL_IMPRINTING = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT_MATERNAL_IMPRINTING;
 
-  public static final TermId AUTOSOMAL_DOMINANT_GERMLINE_DENOVO = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT_GERMLINE_DENOVO;
+  public static final TermId AUTOSOMAL_DOMINANT_GERMLINE_DENOVO = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT_GERMLINE_DENOVO;
 
   /**
    * Autosomal dominant contiguous gene syndrom (alias to {@link #CONTIGUOUS_GENE_SYNDROME}).
    *
    * @see #CONTIGUOUS_GENE_SYNDROME_AUTOSOMAL_DOMINANT
    */
-  public static final TermId AUTOSOMAL_DOMINANT_CONTIGUOUS_GENE_SYNDROME = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT_CONTIGUOUS_GENE_SYNDROME;
+  public static final TermId AUTOSOMAL_DOMINANT_CONTIGUOUS_GENE_SYNDROME = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT_CONTIGUOUS_GENE_SYNDROME;
 
   /** {@link TermId} for "sexSpecific-limited autosomal dominant". */
-  public static final TermId AUTOSOMAL_DOMINANT_SEX_LIMITED = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT_SEX_LIMITED;
+  public static final TermId AUTOSOMAL_DOMINANT_SEX_LIMITED = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT_SEX_LIMITED;
 
   /** {@link TermId} for "male-limited autosomal dominant". */
-  public static final TermId AUTOSOMAL_DOMINANT_MALE_LIMITED = org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT_MALE_LIMITED;
+  public static final TermId AUTOSOMAL_DOMINANT_MALE_LIMITED = org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT_MALE_LIMITED;
 
   private HpoModeOfInheritanceTermIds() {}
 }

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoOnset.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoOnset.java
@@ -3,7 +3,7 @@ package org.monarchinitiative.phenol.annotations.formats.hpo;
 import org.monarchinitiative.phenol.annotations.base.temporal.Age;
 import org.monarchinitiative.phenol.annotations.base.temporal.TemporalInterval;
 import org.monarchinitiative.phenol.annotations.base.temporal.PointInTime;
-import org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds;
+import org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds;
 import org.monarchinitiative.phenol.ontology.data.Identified;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoOnsetTermIds.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoOnsetTermIds.java
@@ -4,24 +4,24 @@ import org.monarchinitiative.phenol.ontology.data.TermId;
 
 
 /**
- * @deprecated the class will be removed in <code>v3.0.0</code>, use {@link org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds} instead.
+ * @deprecated the class will be removed in <code>v3.0.0</code>, use {@link org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds} instead.
  */
 @Deprecated(forRemoval = true, since = "2.0.0-RC2")
 public final class HpoOnsetTermIds {
 
-  public static final TermId ONSET_TERMID = org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds.ONSET;
-  public static final TermId CONGENITAL_ONSET = org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds.CONGENITAL_ONSET;
-  public static final TermId ADULT_ONSET = org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds.ADULT_ONSET;
-  public static final TermId LATE_ONSET = org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds.LATE_ONSET;
-  public static final TermId YOUNG_ADULT_ONSET = org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds.YOUNG_ADULT_ONSET;
-  public static final TermId MIDDLE_AGE_ONSET = org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds.MIDDLE_AGE_ONSET;
-  public static final TermId INFANTILE_ONSET = org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds.INFANTILE_ONSET;
-  public static final TermId ANTENATAL_ONSET = org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds.ANTENATAL_ONSET;
-  public static final TermId EMBRYONAL_ONSET = org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds.EMBRYONAL_ONSET;
-  public static final TermId FETAL_ONSET = org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds.FETAL_ONSET;
-  public static final TermId JUVENILE_ONSET = org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds.JUVENILE_ONSET;
-  public static final TermId NEONATAL_ONSET = org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds.NEONATAL_ONSET;
-  public static final TermId CHILDHOOD_ONSET = org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds.CHILDHOOD_ONSET;
+  public static final TermId ONSET_TERMID = org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds.ONSET;
+  public static final TermId CONGENITAL_ONSET = org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds.CONGENITAL_ONSET;
+  public static final TermId ADULT_ONSET = org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds.ADULT_ONSET;
+  public static final TermId LATE_ONSET = org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds.LATE_ONSET;
+  public static final TermId YOUNG_ADULT_ONSET = org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds.YOUNG_ADULT_ONSET;
+  public static final TermId MIDDLE_AGE_ONSET = org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds.MIDDLE_AGE_ONSET;
+  public static final TermId INFANTILE_ONSET = org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds.INFANTILE_ONSET;
+  public static final TermId ANTENATAL_ONSET = org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds.ANTENATAL_ONSET;
+  public static final TermId EMBRYONAL_ONSET = org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds.EMBRYONAL_ONSET;
+  public static final TermId FETAL_ONSET = org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds.FETAL_ONSET;
+  public static final TermId JUVENILE_ONSET = org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds.JUVENILE_ONSET;
+  public static final TermId NEONATAL_ONSET = org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds.NEONATAL_ONSET;
+  public static final TermId CHILDHOOD_ONSET = org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds.CHILDHOOD_ONSET;
 
   private HpoOnsetTermIds(){}
 }

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoSubOntologyRootTermIds.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoSubOntologyRootTermIds.java
@@ -7,25 +7,25 @@ import org.monarchinitiative.phenol.ontology.data.TermId;
  *
  * @author <a href="mailto:manuel.holtgrewe@bihealth.de">Manuel Holtgrewe</a>
  * @author <a href="mailto:sebastian.koehler@charite.de">Sebastian Koehler</a>
- * @deprecated the class will be removed in <code>v3.0.0</code>, use {@link org.monarchinitiative.phenol.constants.hpo.HpoSubOntologyRootTermIds}.
+ * @deprecated the class will be removed in <code>v3.0.0</code>, use {@link org.monarchinitiative.phenol.annotations.constants.hpo.HpoSubOntologyRootTermIds}.
  */
 @Deprecated(forRemoval = true, since = "2.0.0-RC2")
 public final class HpoSubOntologyRootTermIds {
 
   /** {@link TermId} of sub ontology "phenotypic abnormality" (<code>HP:0000118</code>). */
-  public static final TermId PHENOTYPIC_ABNORMALITY = org.monarchinitiative.phenol.constants.hpo.HpoSubOntologyRootTermIds.PHENOTYPIC_ABNORMALITY;
+  public static final TermId PHENOTYPIC_ABNORMALITY = org.monarchinitiative.phenol.annotations.constants.hpo.HpoSubOntologyRootTermIds.PHENOTYPIC_ABNORMALITY;
 
   /** {@link TermId} of sub ontology "clinical modifier" (<code>HP:0012823</code>). */
-  public static final TermId CLINICAL_MODIFIER = org.monarchinitiative.phenol.constants.hpo.HpoSubOntologyRootTermIds.CLINICAL_MODIFIER;
+  public static final TermId CLINICAL_MODIFIER = org.monarchinitiative.phenol.annotations.constants.hpo.HpoSubOntologyRootTermIds.CLINICAL_MODIFIER;
 
   /** {@link TermId} of sub ontology "mortality/aging" (<code>HP:0040006</code>). */
-  public static final TermId MORTALITY_AGING = org.monarchinitiative.phenol.constants.hpo.HpoSubOntologyRootTermIds.MORTALITY_AGING;
+  public static final TermId MORTALITY_AGING = org.monarchinitiative.phenol.annotations.constants.hpo.HpoSubOntologyRootTermIds.MORTALITY_AGING;
 
   /** {@link TermId} of sub ontology "frequency" (<code>HP:0040279</code>). */
-  public static final TermId FREQUENCY = org.monarchinitiative.phenol.constants.hpo.HpoSubOntologyRootTermIds.FREQUENCY;
+  public static final TermId FREQUENCY = org.monarchinitiative.phenol.annotations.constants.hpo.HpoSubOntologyRootTermIds.FREQUENCY;
 
   /** {@link TermId} of sub ontology "mode of inheritance" (<code>HP:0000005</code>). */
-  public static final TermId MODE_OF_INHERITANCE = org.monarchinitiative.phenol.constants.hpo.HpoSubOntologyRootTermIds.MODE_OF_INHERITANCE;
+  public static final TermId MODE_OF_INHERITANCE = org.monarchinitiative.phenol.annotations.constants.hpo.HpoSubOntologyRootTermIds.MODE_OF_INHERITANCE;
 
   private HpoSubOntologyRootTermIds(){}
 }

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationEntry.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationEntry.java
@@ -4,9 +4,9 @@ package org.monarchinitiative.phenol.annotations.hpo;
 import org.monarchinitiative.phenol.annotations.io.hpo.DiseaseDatabase;
 import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.base.PhenolRuntimeException;
-import org.monarchinitiative.phenol.constants.hpo.HpoClinicalModifierTermIds;
-import org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds;
-import org.monarchinitiative.phenol.constants.hpo.HpoSubOntologyRootTermIds;
+import org.monarchinitiative.phenol.annotations.constants.hpo.HpoClinicalModifierTermIds;
+import org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds;
+import org.monarchinitiative.phenol.annotations.constants.hpo.HpoSubOntologyRootTermIds;
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
@@ -23,8 +23,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm.existsPath;
-import static org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds.*;
-import static org.monarchinitiative.phenol.constants.hpo.HpoOnsetTermIds.*;
+import static org.monarchinitiative.phenol.annotations.constants.hpo.HpoFrequencyTermIds.*;
+import static org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTermIds.*;
 
 
 /**

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/OrphanetInheritanceXMLParser.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/OrphanetInheritanceXMLParser.java
@@ -15,7 +15,7 @@ import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
-import static org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.*;
+import static org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.*;
 
 public class OrphanetInheritanceXMLParser {
   /**

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/OrphanetXML2HpoDiseaseModelParser.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/OrphanetXML2HpoDiseaseModelParser.java
@@ -1,7 +1,7 @@
 package org.monarchinitiative.phenol.annotations.hpo;
 
 import org.monarchinitiative.phenol.base.PhenolRuntimeException;
-import org.monarchinitiative.phenol.constants.hpo.HpoFrequencyTermIds;
+import org.monarchinitiative.phenol.annotations.constants.hpo.HpoFrequencyTermIds;
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 import org.slf4j.Logger;

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/BaseHpoDiseaseLoader.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/BaseHpoDiseaseLoader.java
@@ -3,8 +3,8 @@ package org.monarchinitiative.phenol.annotations.io.hpo;
 import org.monarchinitiative.phenol.annotations.base.Ratio;
 import org.monarchinitiative.phenol.annotations.formats.hpo.*;
 import org.monarchinitiative.phenol.base.PhenolException;
-import org.monarchinitiative.phenol.constants.hpo.HpoClinicalModifierTermIds;
-import org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds;
+import org.monarchinitiative.phenol.annotations.constants.hpo.HpoClinicalModifierTermIds;
+import org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds;
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 import org.slf4j.Logger;
@@ -48,7 +48,7 @@ abstract class BaseHpoDiseaseLoader implements HpoDiseaseLoader {
     this.clinicalCourseSubHierarchy = hpo.containsTerm(HpoClinicalModifierTermIds.CLINICAL_COURSE)
       ? hpo.subOntology(HpoClinicalModifierTermIds.CLINICAL_COURSE).getNonObsoleteTermIds()
       : Set.of();
-    this.inheritanceSubHierarchy = hpo.containsTerm(org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.INHERITANCE_ROOT)
+    this.inheritanceSubHierarchy = hpo.containsTerm(HpoModeOfInheritanceTermIds.INHERITANCE_ROOT)
       ? hpo.subOntology(HpoModeOfInheritanceTermIds.INHERITANCE_ROOT).getNonObsoleteTermIds()
       : Set.of();
   }

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderDefault.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderDefault.java
@@ -7,7 +7,7 @@ import org.monarchinitiative.phenol.annotations.formats.AnnotationReference;
 import org.monarchinitiative.phenol.annotations.formats.EvidenceCode;
 import org.monarchinitiative.phenol.annotations.formats.hpo.*;
 import org.monarchinitiative.phenol.base.PhenolRuntimeException;
-import org.monarchinitiative.phenol.constants.hpo.HpoSubOntologyRootTermIds;
+import org.monarchinitiative.phenol.annotations.constants.hpo.HpoSubOntologyRootTermIds;
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 import org.slf4j.Logger;

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderV2.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderV2.java
@@ -8,7 +8,7 @@ import org.monarchinitiative.phenol.annotations.formats.hpo.HpoDisease;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoDiseaseAnnotation;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoOnset;
 import org.monarchinitiative.phenol.base.PhenolRuntimeException;
-import org.monarchinitiative.phenol.constants.hpo.HpoSubOntologyRootTermIds;
+import org.monarchinitiative.phenol.annotations.constants.hpo.HpoSubOntologyRootTermIds;
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 import org.slf4j.Logger;

--- a/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/hpo/OrphanetInheritanceXMLParserTest.java
+++ b/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/hpo/OrphanetInheritanceXMLParserTest.java
@@ -14,8 +14,8 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT;
-import static org.monarchinitiative.phenol.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_RECESSIVE;
+import static org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_DOMINANT;
+import static org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.AUTOSOMAL_RECESSIVE;
 
 public class OrphanetInheritanceXMLParserTest {
 

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/PrecomputeScores.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/PrecomputeScores.java
@@ -2,7 +2,7 @@ package org.monarchinitiative.phenol.cli.demo;
 
 import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoGeneAnnotation;
-import org.monarchinitiative.phenol.constants.hpo.HpoSubOntologyRootTermIds;
+import org.monarchinitiative.phenol.annotations.constants.hpo.HpoSubOntologyRootTermIds;
 import org.monarchinitiative.phenol.io.OntologyLoader;
 import org.monarchinitiative.phenol.ontology.algo.InformationContentComputation;
 import org.monarchinitiative.phenol.ontology.data.Ontology;

--- a/phenol-core/src/main/java/module-info.java
+++ b/phenol-core/src/main/java/module-info.java
@@ -1,6 +1,5 @@
 module org.monarchinitiative.phenol.core {
   exports org.monarchinitiative.phenol.base;
-  exports org.monarchinitiative.phenol.constants.hpo;
   exports org.monarchinitiative.phenol.graph;
   exports org.monarchinitiative.phenol.ontology.data;
   exports org.monarchinitiative.phenol.ontology.algo;


### PR DESCRIPTION
The HPO constants are moved from `phenol-core` to `phenol-annotations`, to keep `phenol-core` largely ontology agnostic.

Fixes #401 .