### PR TITLE
Improve HPOA loading

### DIFF
--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderOptions.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderOptions.java
@@ -17,7 +17,7 @@ public class HpoDiseaseLoaderOptions {
   private final int cohortSize;
 
   /**
-   * Get options where:
+   * Get {@link HpoDiseaseLoaderOptions} where:
    * <ul>
    *   <li><em>OMIM</em>, <em>ORPHA</em>, and <em>DECIPHER</em> diseases will be loaded</li>
    *   <li>suspicious frequencies of negated terms will be salvaged, if possible, and</li>
@@ -26,6 +26,24 @@ public class HpoDiseaseLoaderOptions {
    */
   public static HpoDiseaseLoaderOptions defaultOptions() {
     return of(DATABASE_PREFIXES, true, DEFAULT_COHORT_SIZE);
+  }
+
+  /**
+   * Get {@link HpoDiseaseLoaderOptions} for instructing the {@link HpoDiseaseLoader} to load
+   * {@link DiseaseDatabase#OMIM} diseases, to try to salvage the suspicious frequencies of negated terms,
+   * and to assume a cohort size corresponding to {@link #DEFAULT_COHORT_SIZE}.
+   */
+  public static HpoDiseaseLoaderOptions defaultOmim() {
+    return of(Set.of(DiseaseDatabase.OMIM));
+  }
+
+  /**
+   * Get {@link HpoDiseaseLoaderOptions} for instructing the {@link HpoDiseaseLoader} to load diseases
+   * with given {@code databasePrefixes}, to try to salvage the suspicious frequencies of negated terms,
+   * and to assume a cohort size corresponding to {@link #DEFAULT_COHORT_SIZE}.
+   */
+  public static HpoDiseaseLoaderOptions of(Set<DiseaseDatabase> databasePrefixes) {
+    return of(databasePrefixes, true, DEFAULT_COHORT_SIZE);
   }
 
   public static HpoDiseaseLoaderOptions of(Set<DiseaseDatabase> databasePrefixes, boolean salvageNegatedFrequencies, int cohortSize) {

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderOptions.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderOptions.java
@@ -11,7 +11,7 @@ public class HpoDiseaseLoaderOptions {
   /**
    * The assumed cohort size used to parse annotation lines with no explicit phenotype frequency data.
    */
-  public static final int DEFAULT_COHORT_SIZE = 50;
+  public static final int DEFAULT_COHORT_SIZE = 5;
   private final Set<DiseaseDatabase> includedDatabases;
   private final boolean salvageNegatedFrequencies;
   private final int cohortSize;
@@ -19,9 +19,9 @@ public class HpoDiseaseLoaderOptions {
   /**
    * Get {@link HpoDiseaseLoaderOptions} where:
    * <ul>
-   *   <li><em>OMIM</em>, <em>ORPHA</em>, and <em>DECIPHER</em> diseases will be loaded</li>
+   *   <li>{@link DiseaseDatabase#OMIM}, {@link DiseaseDatabase#ORPHANET}, and {@link DiseaseDatabase#DECIPHER} diseases will be loaded</li>
    *   <li>suspicious frequencies of negated terms will be salvaged, if possible, and</li>
-   *   <li>a cohort is assumed to have <code>50</code> members by default</li>
+   *   <li>a cohort is assumed to include {@link #DEFAULT_COHORT_SIZE} members by default</li>
    * </ul>
    */
   public static HpoDiseaseLoaderOptions defaultOptions() {
@@ -46,6 +46,14 @@ public class HpoDiseaseLoaderOptions {
     return of(databasePrefixes, true, DEFAULT_COHORT_SIZE);
   }
 
+  /**
+   * Create {@link HpoDiseaseLoaderOptions} for parameterizing the disease loading by {@link HpoDiseaseLoader}.
+   *
+   * @param databasePrefixes a set of {@link DiseaseDatabase} prefixes of diseases to load.
+   * @param salvageNegatedFrequencies set to {@code true} if the loader should try to salvage suspicious frequencies of the negated terms.
+   * @param cohortSize a positive integer corresponding to the assumed cohort size to parse annotation lines with
+   *                   no explicit phenotype frequency data.
+   */
   public static HpoDiseaseLoaderOptions of(Set<DiseaseDatabase> databasePrefixes, boolean salvageNegatedFrequencies, int cohortSize) {
     return new HpoDiseaseLoaderOptions(databasePrefixes, salvageNegatedFrequencies, cohortSize);
   }
@@ -85,7 +93,7 @@ public class HpoDiseaseLoaderOptions {
 
   @Override
   public String toString() {
-    return "Options{" +
+    return "HpoDiseaseLoaderOptions{" +
       "includedDatabases=" + includedDatabases +
       ", salvageNegatedFrequencies=" + salvageNegatedFrequencies +
       ", cohortSize=" + cohortSize +

--- a/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderDefaultTest.java
+++ b/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderDefaultTest.java
@@ -28,6 +28,7 @@ public class HpoDiseaseLoaderDefaultTest {
 
   private static final Path HPOA = TestBase.TEST_BASE.resolve("annotations").resolve("phenotype.fake.hpoa");
   private static final Path HPO_PATH = TestBase.TEST_BASE.resolve("hpo_toy.json");
+  private static final HpoDiseaseLoaderOptions OPTIONS = HpoDiseaseLoaderOptions.defaultOptions();
 
   private static Ontology HPO;
 
@@ -40,7 +41,7 @@ public class HpoDiseaseLoaderDefaultTest {
 
   @BeforeEach
   public void setUp() {
-    instance = HpoDiseaseLoaders.defaultLoader(HPO, HpoDiseaseLoaderOptions.defaultOptions());
+    instance = HpoDiseaseLoaders.defaultLoader(HPO, OPTIONS);
   }
 
   @Test
@@ -98,7 +99,7 @@ public class HpoDiseaseLoaderDefaultTest {
     HpoDiseaseAnnotation second = annotations.get(1);
     assertThat(second.id().getValue(), equalTo("HP:0001238"));
     assertThat(second.isPresent(), equalTo(false));
-    assertThat(second.ratio(), equalTo(Ratio.of(0, 50)));
+    assertThat(second.ratio(), equalTo(Ratio.of(0, OPTIONS.cohortSize())));
 
     assertThat(second.earliestOnset().isEmpty(), equalTo(true));
 

--- a/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderV2Test.java
+++ b/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderV2Test.java
@@ -27,6 +27,7 @@ public class HpoDiseaseLoaderV2Test {
 
   private static final Path HPOA = TestBase.TEST_BASE.resolve("annotations").resolve("phenotype.fake.hpoa");
   private static final Path HPO_PATH = TestBase.TEST_BASE.resolve("hpo_toy.json");
+  private static final HpoDiseaseLoaderOptions OPTIONS = HpoDiseaseLoaderOptions.defaultOptions();
 
   private static Ontology HPO;
 
@@ -39,7 +40,7 @@ public class HpoDiseaseLoaderV2Test {
 
   @BeforeEach
   public void setUp() {
-    instance = new HpoDiseaseLoaderV2(HPO, HpoDiseaseLoaderOptions.defaultOptions());
+    instance = new HpoDiseaseLoaderV2(HPO, OPTIONS);
   }
 
   @Test
@@ -81,7 +82,7 @@ public class HpoDiseaseLoaderV2Test {
 
     HpoDiseaseAnnotation second = annotations.get(1);
     assertThat(second.id().getValue(), equalTo("HP:0001238"));
-    assertThat(second.ratio(), equalTo(Ratio.of(0, 50)));
+    assertThat(second.ratio(), equalTo(Ratio.of(0, OPTIONS.cohortSize())));
     assertThat(second.references(), hasSize(1));
     assertThat(second.references(), hasItem(AnnotationReference.of(TermId.of("PMID:20375004"), EvidenceCode.PCS)));
     assertThat(second.earliestOnset().isEmpty(), equalTo(true));


### PR DESCRIPTION
Add convenience static factory methods to `HpoDiseaseLoaderOptions`. Set default cohort size to `5`.

Fixes #402 and #403 