### PR TITLE
extended interface of AssociationContainer by new method

### DIFF
--- a/phenol-analysis/src/main/java/org/monarchinitiative/phenol/analysis/AssociationContainer.java
+++ b/phenol-analysis/src/main/java/org/monarchinitiative/phenol/analysis/AssociationContainer.java
@@ -27,6 +27,12 @@ public interface AssociationContainer<T> {
   Map<T, DirectAndIndirectTermAnnotations> getAssociationMap(Set<TermId> annotatedItemTermIds);
 
   Set<T> getAllAnnotatedGenes();
+
+  /**
+   * @param tid The {@link TermId} of an ontology term (e.g. Gene Ontology) used to annotated domain items
+   * @return A set of domain items (e.g., genes) annotated by the ontology term
+   */
+  Set<T> getDomainItemsAnnotatedByOntologyTerm(TermId tid);
   /**
    * @return total number of GO (or HP, MP, etc) terms that are annotating the items in this container.
    */

--- a/phenol-analysis/src/main/java/org/monarchinitiative/phenol/analysis/GoAssociationContainer.java
+++ b/phenol-analysis/src/main/java/org/monarchinitiative/phenol/analysis/GoAssociationContainer.java
@@ -86,6 +86,22 @@ public class GoAssociationContainer implements AssociationContainer<TermId> {
     return this.gene2associationMap.keySet();
   }
 
+  @Override
+  public Set<TermId> getDomainItemsAnnotatedByOntologyTerm(TermId tid) {
+    Set<TermId> domainItemSet = new HashSet<>();
+    // the following includes tid in the descendent set
+    Set<TermId> descendentSet = OntologyAlgorithm.getDescendents(this.ontology, tid);
+    for (Map.Entry<TermId, GeneAnnotations> entry : gene2associationMap.entrySet()) {
+      TermId gene = entry.getKey();
+      for (TermId ontologyTermId : entry.getValue().getAnnotatingTermIds()) {
+        if (descendentSet.contains(ontologyTermId) || ontologyTermId.equals(tid)) {
+          domainItemSet.add(gene);
+        }
+      }
+    }
+    return domainItemSet;
+  }
+
   /**
    * @return number of genes (or items) represented in this association container.
    */

--- a/phenol-analysis/src/main/java/org/monarchinitiative/phenol/analysis/GoAssociationContainer.java
+++ b/phenol-analysis/src/main/java/org/monarchinitiative/phenol/analysis/GoAssociationContainer.java
@@ -1,5 +1,6 @@
 package org.monarchinitiative.phenol.analysis;
 
+import org.monarchinitiative.phenol.analysis.util.Util;
 import org.monarchinitiative.phenol.annotations.formats.go.GoGaf22Annotation;
 import org.monarchinitiative.phenol.annotations.io.go.GoGeneAnnotationParser;
 import org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm;
@@ -88,18 +89,7 @@ public class GoAssociationContainer implements AssociationContainer<TermId> {
 
   @Override
   public Set<TermId> getDomainItemsAnnotatedByOntologyTerm(TermId tid) {
-    Set<TermId> domainItemSet = new HashSet<>();
-    // the following includes tid in the descendent set
-    Set<TermId> descendentSet = OntologyAlgorithm.getDescendents(this.ontology, tid);
-    for (Map.Entry<TermId, GeneAnnotations> entry : gene2associationMap.entrySet()) {
-      TermId gene = entry.getKey();
-      for (TermId ontologyTermId : entry.getValue().getAnnotatingTermIds()) {
-        if (descendentSet.contains(ontologyTermId) || ontologyTermId.equals(tid)) {
-          domainItemSet.add(gene);
-        }
-      }
-    }
-    return domainItemSet;
+    return Util.getDomainItemsAnnotatedByOntologyTerm(tid, ontology, gene2associationMap);
   }
 
   /**

--- a/phenol-analysis/src/main/java/org/monarchinitiative/phenol/analysis/TermAssociationContainer.java
+++ b/phenol-analysis/src/main/java/org/monarchinitiative/phenol/analysis/TermAssociationContainer.java
@@ -1,6 +1,7 @@
 package org.monarchinitiative.phenol.analysis;
 
 
+import org.monarchinitiative.phenol.analysis.util.Util;
 import org.monarchinitiative.phenol.annotations.io.go.GoGeneAnnotationParser;
 import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm;
@@ -114,18 +115,7 @@ public class TermAssociationContainer implements AssociationContainer<TermId> {
 
   @Override
   public Set<TermId> getDomainItemsAnnotatedByOntologyTerm(TermId tid) {
-    Set<TermId> domainItemSet = new HashSet<>();
-    // the following includes tid in the descendent set
-    Set<TermId> descendentSet = OntologyAlgorithm.getDescendents(this.ontology, tid);
-    for (Map.Entry<TermId, GeneAnnotations> entry : gene2associationMap.entrySet()) {
-      TermId gene = entry.getKey();
-      for (TermId ontologyTermId : entry.getValue().getAnnotatingTermIds()) {
-        if (descendentSet.contains(ontologyTermId) || ontologyTermId.equals(tid)) {
-          domainItemSet.add(gene);
-        }
-      }
-    }
-    return domainItemSet;
+    return Util.getDomainItemsAnnotatedByOntologyTerm(tid, ontology, gene2associationMap);
   }
 
   /**

--- a/phenol-analysis/src/main/java/org/monarchinitiative/phenol/analysis/TermAssociationContainer.java
+++ b/phenol-analysis/src/main/java/org/monarchinitiative/phenol/analysis/TermAssociationContainer.java
@@ -112,6 +112,22 @@ public class TermAssociationContainer implements AssociationContainer<TermId> {
     return this.gene2associationMap.keySet();
   }
 
+  @Override
+  public Set<TermId> getDomainItemsAnnotatedByOntologyTerm(TermId tid) {
+    Set<TermId> domainItemSet = new HashSet<>();
+    // the following includes tid in the descendent set
+    Set<TermId> descendentSet = OntologyAlgorithm.getDescendents(this.ontology, tid);
+    for (Map.Entry<TermId, GeneAnnotations> entry : gene2associationMap.entrySet()) {
+      TermId gene = entry.getKey();
+      for (TermId ontologyTermId : entry.getValue().getAnnotatingTermIds()) {
+        if (descendentSet.contains(ontologyTermId) || ontologyTermId.equals(tid)) {
+          domainItemSet.add(gene);
+        }
+      }
+    }
+    return domainItemSet;
+  }
+
   /**
    * @return number of genes (or items) represented in this association container.
    */

--- a/phenol-analysis/src/main/java/org/monarchinitiative/phenol/analysis/util/Util.java
+++ b/phenol-analysis/src/main/java/org/monarchinitiative/phenol/analysis/util/Util.java
@@ -1,0 +1,33 @@
+package org.monarchinitiative.phenol.analysis.util;
+
+import org.monarchinitiative.phenol.analysis.ItemAnnotations;
+import org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm;
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class Util {
+
+  public static Set<TermId> getDomainItemsAnnotatedByOntologyTerm(TermId termId,
+                                                                  Ontology ontology,
+                                                                  Map<TermId, ? extends ItemAnnotations<TermId>> gene2associationMap) {
+    Set<TermId> domainItemSet = new HashSet<>();
+    // the following includes tid in the descendent set
+    Set<TermId> descendentSet = OntologyAlgorithm.getDescendents(ontology, termId);
+
+    for (Map.Entry<TermId, ? extends ItemAnnotations<TermId>> entry : gene2associationMap.entrySet()) {
+      TermId gene = entry.getKey();
+      for (TermId ontologyTermId : entry.getValue().getAnnotatingTermIds()) {
+        if (descendentSet.contains(ontologyTermId) || ontologyTermId.equals(termId)) {
+          domainItemSet.add(gene);
+        }
+      }
+    }
+
+    return domainItemSet;
+  }
+
+}

--- a/phenol-analysis/src/main/java/org/monarchinitiative/phenol/analysis/util/Util.java
+++ b/phenol-analysis/src/main/java/org/monarchinitiative/phenol/analysis/util/Util.java
@@ -15,7 +15,7 @@ public class Util {
                                                                   Ontology ontology,
                                                                   Map<TermId, ? extends ItemAnnotations<TermId>> gene2associationMap) {
     Set<TermId> domainItemSet = new HashSet<>();
-    // the following includes tid in the descendent set
+    // the following includes termId in the descendent set
     Set<TermId> descendentSet = OntologyAlgorithm.getDescendents(ontology, termId);
 
     for (Map.Entry<TermId, ? extends ItemAnnotations<TermId>> entry : gene2associationMap.entrySet()) {


### PR DESCRIPTION
Adding ``Set<T> getDomainItemsAnnotatedByOntologyTerm(TermId tid);`` to interface AssociationContainer<T> because it is needed in Isopret.