### PR TITLE
Offer versions in data containers/resource objects

### DIFF
--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseases.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseases.java
@@ -2,6 +2,7 @@ package org.monarchinitiative.phenol.annotations.formats.hpo;
 
 import org.monarchinitiative.phenol.ontology.data.Identified;
 import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.monarchinitiative.phenol.ontology.data.Versioned;
 
 import java.util.*;
 import java.util.function.Function;
@@ -9,10 +10,22 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-public interface HpoDiseases extends AnnotatedItemContainer<HpoDisease> {
+/**
+ * A {@link Versioned} container for {@link HpoDisease}s with a bunch of convenience methods for getting
+ * the individual {@link HpoDisease}s.
+ */
+public interface HpoDiseases extends AnnotatedItemContainer<HpoDisease>, Versioned {
 
+  /**
+   * @deprecated use {@link #of(String, List)} instead.
+   */
+  @Deprecated(forRemoval = true)
   static HpoDiseases of(List<HpoDisease> diseases) {
-    return new HpoDiseasesDefault(diseases);
+    return of(null, diseases);
+  }
+
+  static HpoDiseases of(String version, List<HpoDisease> diseases) {
+    return new HpoDiseasesDefault(version, diseases);
   }
 
   Optional<HpoDisease> diseaseById(TermId diseaseId);

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseasesDefault.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseasesDefault.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
  */
 class HpoDiseasesDefault implements HpoDiseases {
 
+  private final String version; // nullable
   private final List<HpoDisease> hpoDiseases;
   /*
   We use double check locking for lazy initialization.
@@ -19,7 +20,8 @@ class HpoDiseasesDefault implements HpoDiseases {
    */
   private volatile Map<TermId, HpoDisease> diseaseById;
 
-  HpoDiseasesDefault(List<HpoDisease> hpoDiseases) {
+  HpoDiseasesDefault(String version, List<HpoDisease> hpoDiseases) {
+    this.version = version; // nullable
     this.hpoDiseases = Objects.requireNonNull(hpoDiseases, "HPO diseases must not be null");
   }
 
@@ -57,5 +59,10 @@ class HpoDiseasesDefault implements HpoDiseases {
   @Override
   public Set<TermId> diseaseIds() {
     return diseaseById().keySet();
+  }
+
+  @Override
+  public Optional<String> version() {
+    return Optional.ofNullable(version);
   }
 }

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderDefault.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderDefault.java
@@ -63,7 +63,7 @@ class HpoDiseaseLoaderDefault implements HpoDiseaseLoader  {
       .flatMap(Optional::stream)
       .collect(Collectors.toUnmodifiableList());
 
-    return HpoDiseases.of(diseases);
+    return HpoDiseases.of(container.version().orElse(null), diseases);
   }
 
   private static TemporalInterval calculateGlobalOnset(Iterable<HpoDiseaseAnnotation> annotations) {

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoaDiseaseDataContainer.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoaDiseaseDataContainer.java
@@ -1,14 +1,17 @@
 package org.monarchinitiative.phenol.annotations.io.hpo;
 
 import org.monarchinitiative.phenol.annotations.formats.hpo.AnnotatedItemContainer;
+import org.monarchinitiative.phenol.ontology.data.Versioned;
 
 import java.util.*;
 
-public class HpoaDiseaseDataContainer implements AnnotatedItemContainer<HpoaDiseaseData> {
+public class HpoaDiseaseDataContainer implements AnnotatedItemContainer<HpoaDiseaseData>, Versioned {
 
+  private final String version; // nullable
   private final List<HpoaDiseaseData> diseaseData;
 
-  public HpoaDiseaseDataContainer(List<HpoaDiseaseData> diseaseData) {
+  HpoaDiseaseDataContainer(String version, List<HpoaDiseaseData> diseaseData) {
+    this.version = version; // nullable
     this.diseaseData = Objects.requireNonNull(diseaseData);
   }
 
@@ -21,4 +24,8 @@ public class HpoaDiseaseDataContainer implements AnnotatedItemContainer<HpoaDise
     return diseaseData;
   }
 
+  @Override
+  public Optional<String> version() {
+    return Optional.ofNullable(version);
+  }
 }

--- a/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderDefaultTest.java
+++ b/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaderDefaultTest.java
@@ -94,4 +94,12 @@ public class HpoDiseaseLoaderDefaultTest {
     assertThat(second.earliestOnset().isEmpty(), equalTo(true));
     assertThat(second.latestOnset().isEmpty(), equalTo(true));
   }
+
+  @Test
+  public void diseaseDataHasVersion() throws Exception {
+    HpoDiseases diseases = instance.load(HPOA);
+
+    assertThat(diseases.version().isPresent(), equalTo(true));
+    assertThat(diseases.version().get(), equalTo("2021-08-02"));
+  }
 }

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/ImmutableOntology.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/ImmutableOntology.java
@@ -259,6 +259,11 @@ public class ImmutableOntology implements Ontology {
     }
   }
 
+  @Override
+  public Optional<String> version() {
+    return Optional.ofNullable(metaInfo.get("release"));
+  }
+
   public static Builder builder() {
     return new Builder();
   }

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/MinimalOntology.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/MinimalOntology.java
@@ -64,7 +64,7 @@ import org.monarchinitiative.phenol.graph.IdLabeledEdge;
  * @author <a href="mailto:sebastian.koehler@charite.de">Sebastian Koehler</a>
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  */
-public interface MinimalOntology extends Serializable {
+public interface MinimalOntology extends Serializable, Versioned {
   long serialVersionUID = 2L;
   /** @return {@link Map} with ontology meta information, e.g., as loaded from file. */
   Map<String, String> getMetaInfo();

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Versioned.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Versioned.java
@@ -1,0 +1,15 @@
+package org.monarchinitiative.phenol.ontology.data;
+
+import java.util.Optional;
+
+/**
+ * Implementors have an optional version.
+ */
+public interface Versioned {
+
+  /**
+   * @return {@link Optional} version {@link String} or an empty {@link Optional} if the version is not available.
+   */
+  Optional<String> version();
+
+}

--- a/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderHpoTest.java
+++ b/phenol-io/src/test/java/org/monarchinitiative/phenol/io/OntologyLoaderHpoTest.java
@@ -15,6 +15,7 @@ import org.monarchinitiative.phenol.ontology.data.TermSynonym;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -125,4 +126,10 @@ public class OntologyLoaderHpoTest {
     assertThat(syn3.isLayperson(), is(false));
   }
 
+  @Test
+  public void ontologyHasVersion() {
+    Optional<String> version = hpo.version();
+    assertThat(version.isPresent(), equalTo(true));
+    assertThat(version.get(), equalTo("2021-06-08"));
+  }
 }


### PR DESCRIPTION
It is desirable to keep track of the versions of the used resources. The PR adds `Versioned` interface that is implemented by resource objects/containers. The version is just a simple string and it is optional:

```
public interface Versioned {

  /**
   * @return {@link Optional} version {@link String} or an empty {@link Optional} if the version is not available.
   */
  Optional<String> version();

}
```

For start, `Versioned` is implemented by `MinimalOntology` and `HpoDiseases`.