### PR TITLE
Add `precompute-resnik` command

### DIFF
--- a/phenol-cli/pom.xml
+++ b/phenol-cli/pom.xml
@@ -27,6 +27,14 @@
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/phenol-cli/src/main/java/module-info.java
+++ b/phenol-cli/src/main/java/module-info.java
@@ -2,6 +2,7 @@ module org.monarchinitiative.phenol.cli {
   requires org.monarchinitiative.phenol.io;
   requires org.monarchinitiative.phenol.analysis;
 
+  requires commons.csv;
   requires info.picocli;
   requires org.slf4j;
 }

--- a/phenol-cli/src/main/java/module-info.java
+++ b/phenol-cli/src/main/java/module-info.java
@@ -5,4 +5,6 @@ module org.monarchinitiative.phenol.cli {
   requires commons.csv;
   requires info.picocli;
   requires org.slf4j;
+
+  exports org.monarchinitiative.phenol.cli.cmd to info.picocli;
 }

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/Main.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/Main.java
@@ -25,6 +25,7 @@ public class Main implements Callable<Integer> {
       .addSubcommand("mpo", new MpDemoCommand())
       .addSubcommand("precompute-scores", new PrecomputeScoresCommand())
       .addSubcommand("resnik-gene", new ResnikCommand())
+      .addSubcommand("precompute-resnik", new PrecomputeResnikMapCommand())
       ;
     cline.setToggleBooleanFlags(false);
     int exitCode = cline.execute(args);

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/cmd/GoCommand.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/cmd/GoCommand.java
@@ -11,15 +11,15 @@ import java.util.concurrent.Callable;
 public class GoCommand implements Callable<Integer> {
 
   @CommandLine.Option(names = {"-o", "--obo"}, description = "path to go.obo file", required = true)
-  private String pathGoObo;
+  public String pathGoObo;
   @CommandLine.Option(names = {"-a", "--annot"}, description = "path to go association file (e.g., goa_human.gaf", required = true)
-  private String pathGoGaf;
+  public String pathGoGaf;
   /**
    * For the demo, We will create a study set that has 1/3 of the genes associated with this term
    * and three times as many other terms. The default GO:0070997 is 'neuron death'.
    */
   @CommandLine.Option(names = {"-i", "--id"}, description = "term ID to search for enrichment")
-  private String goTermId = "GO:0097190";
+  public String goTermId = "GO:0097190";
 
   @Override
   public Integer call() {

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/cmd/HpDemoCommand.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/cmd/HpDemoCommand.java
@@ -12,9 +12,9 @@ import java.util.concurrent.Callable;
 public class HpDemoCommand implements Callable<Integer> {
 
     @CommandLine.Option(names = {"-o","--obo"}, description = "path to hp.obo file", required = true)
-    private String hpoPath;
+    public String hpoPath;
     @CommandLine.Option(names = {"-a","--annot"}, description = "path to HPO annotation file (phenotyoe.hpoa", required = true)
-    private String annotPath;
+    public String annotPath;
 
 
 

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/cmd/MondoDemoCommand.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/cmd/MondoDemoCommand.java
@@ -11,9 +11,9 @@ import java.util.concurrent.Callable;
 public class MondoDemoCommand implements Callable<Integer> {
 
   @CommandLine.Option(names = {"-m", "--mondo"}, description = "path to mondo.obo file", required = true)
-  private String mondoPath;
+  public String mondoPath;
   @CommandLine.Option(names = {"-o", "--outfile"}, description = "name/path of output file", required = true)
-  private String outPath;
+  public String outPath;
 
 
   @Override

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/cmd/MpDemoCommand.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/cmd/MpDemoCommand.java
@@ -12,19 +12,19 @@ public class MpDemoCommand implements Callable<Integer> {
 
 
   @CommandLine.Option(names = {"-o", "--obo"}, description = "path to mp.obo file", required = true)
-  private String oboPath;
+  public String oboPath;
 
   @CommandLine.Option(names = {"-a", "--annot"}, description = "path to association file (MGI_GenePheno.rpt)", required = true)
-  private String annotPath;
+  public String annotPath;
   /**
    * For the demo, We will create a study set that has 1/3 of the genes associated with this term
    * and three times as many other terms. The default GO:0070997 is 'neuron death'.
    */
   @CommandLine.Option(names = {"-i", "--input"}, description = "list of gene symbols (study set)", required = true)
-  private String inputGeneList;
+  public String inputGeneList;
 
   @CommandLine.Option(names = {"-m", "--marker"}, description = "Marker file, MRK_List2.rpt")
-  private String markerFile;
+  public String markerFile;
 
 
   @Override

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/cmd/PrecomputeResnikMapCommand.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/cmd/PrecomputeResnikMapCommand.java
@@ -1,0 +1,122 @@
+package org.monarchinitiative.phenol.cli.cmd;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.monarchinitiative.phenol.annotations.formats.hpo.HpoDiseases;
+import org.monarchinitiative.phenol.annotations.io.hpo.HpoDiseaseLoader;
+import org.monarchinitiative.phenol.annotations.io.hpo.HpoDiseaseLoaderOptions;
+import org.monarchinitiative.phenol.annotations.io.hpo.HpoDiseaseLoaders;
+import org.monarchinitiative.phenol.cli.demo.MicaCalculator;
+import org.monarchinitiative.phenol.io.OntologyLoader;
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.monarchinitiative.phenol.ontology.similarity.HpoResnikSimilarity;
+import org.monarchinitiative.phenol.ontology.similarity.TermPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Precompute MICA information content for HPO and {@link HpoDiseases} and write the information contents
+ * of the term pairs into a table.
+ */
+@CommandLine.Command(name = "precompute-resnik",
+  mixinStandardHelpOptions = true,
+  description = "Precompute Resnik term pair similarity table")
+public class PrecomputeResnikMapCommand implements Callable<Integer> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PrecomputeResnikMapCommand.class);
+
+  @CommandLine.Option(names = {"--hpo"},
+    description = "path to hp.json file",
+    required = true)
+  public Path hpoPath;
+
+  @CommandLine.Option(names = "--hpoa",
+    description = "path to phenotype.hpoa file",
+    required = true)
+  public Path hpoaPath;
+
+  @CommandLine.Option(names = {"--output"},
+    description = "Where to write the term pair similarity table (default: ${DEFAULT-VALUE})")
+  public Path output = Path.of("term-pair-similarity.csv.gz");
+
+  @Override
+  public Integer call() throws Exception {
+    LOGGER.info("Loading HPO from {}", hpoPath.toAbsolutePath());
+    Ontology hpo = OntologyLoader.loadOntology(hpoPath.toFile());
+
+    LOGGER.info("Loading HPO annotations from {}", hpoaPath.toAbsolutePath());
+    HpoDiseaseLoader loader = HpoDiseaseLoaders.defaultLoader(hpo, HpoDiseaseLoaderOptions.defaultOptions());
+    HpoDiseases diseases = loader.load(hpoaPath);
+
+    LOGGER.info("Calculating information content using {} diseases", diseases.size());
+    Map<TermId, Double> termToIc = calculateTermToIc(hpo, diseases);
+
+    LOGGER.info("Assigning MICA information content to term pairs");
+    Map<TermPair, Double> termPairResnikSimilarityMap = assignMicaToTermPairs(hpo, termToIc);
+
+    LOGGER.info("Writing term pair similarity to {}", output.toAbsolutePath());
+    LocalDate date = LocalDate.now();
+    String hpoVersion = hpo.version().orElse("N/A");
+    String hpoaVersion = diseases.version().orElse("N/A");
+    writeTermPairMap(termPairResnikSimilarityMap, date, hpoVersion, hpoaVersion);
+
+    LOGGER.info("Done!");
+    return 0;
+  }
+
+  private static Map<TermId, Double> calculateTermToIc(Ontology hpo, HpoDiseases diseases) {
+    MicaCalculator micaCalculator = new MicaCalculator(hpo);
+    return micaCalculator.calculateMica(diseases).termToIc();
+  }
+
+  private static Map<TermPair, Double> assignMicaToTermPairs(Ontology hpo, Map<TermId, Double> termToIc) {
+    HpoResnikSimilarity similarity = new HpoResnikSimilarity(hpo, termToIc);
+    return similarity.getTermPairResnikSimilarityMap();
+  }
+
+  private void writeTermPairMap(Map<TermPair, Double> termPairResnikSimilarityMap,
+                                LocalDate now,
+                                String hpoVersion,
+                                String hpoaVersion) throws IOException {
+    try (Writer writer = openWriter();
+         CSVPrinter printer = CSVFormat.Builder.create(CSVFormat.DEFAULT)
+           .setCommentMarker('#')
+           .build()
+           .print(writer)) {
+      // Metadata
+      printer.printComment("Information content of the most informative common ancestor for term pairs");
+      printer.printComment(String.format("HPO=%s;HPOA=%s;CREATED=%s", hpoVersion, hpoaVersion, now));
+
+      // Header
+      printer.printRecord("term_a", "term_b", "ic_mica");
+
+      // Content
+      for (Map.Entry<TermPair, Double> e : termPairResnikSimilarityMap.entrySet()) {
+        TermPair pair = e.getKey();
+        printer.print(pair.getTidA().getValue());
+        printer.print(pair.getTidB().getValue());
+        printer.print(e.getValue());
+        printer.println();
+      }
+    }
+  }
+
+  private Writer openWriter() throws IOException {
+    return output.toFile().getName().endsWith(".gz")
+      ? new BufferedWriter(new OutputStreamWriter(new GZIPOutputStream(Files.newOutputStream(output))))
+      : Files.newBufferedWriter(output);
+  }
+}

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/cmd/PrecomputeResnikMapCommand.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/cmd/PrecomputeResnikMapCommand.java
@@ -48,6 +48,10 @@ public class PrecomputeResnikMapCommand implements Callable<Integer> {
     required = true)
   public Path hpoaPath;
 
+  @CommandLine.Option(names = {"--assume-annotated"},
+    description = {"Assume that each term annotates at least one disease.", "This prevents IC=Infinity for the absent terms"})
+  public boolean assumeAnnotated;
+
   @CommandLine.Option(names = {"--output"},
     description = "Where to write the term pair similarity table (default: ${DEFAULT-VALUE})")
   public Path output = Path.of("term-pair-similarity.csv.gz");
@@ -77,8 +81,8 @@ public class PrecomputeResnikMapCommand implements Callable<Integer> {
     return 0;
   }
 
-  private static Map<TermId, Double> calculateTermToIc(Ontology hpo, HpoDiseases diseases) {
-    MicaCalculator micaCalculator = new MicaCalculator(hpo);
+  private Map<TermId, Double> calculateTermToIc(Ontology hpo, HpoDiseases diseases) {
+    MicaCalculator micaCalculator = new MicaCalculator(hpo, assumeAnnotated);
     return micaCalculator.calculateMica(diseases).termToIc();
   }
 

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/cmd/PrecomputeScoresCommand.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/cmd/PrecomputeScoresCommand.java
@@ -20,53 +20,53 @@ public class PrecomputeScoresCommand implements Callable<Integer> {
     names = {"-t", "--num-threads"},
     description = "Number of threads to use."
   )
-  private int numThreads = 1;
+  public int numThreads = 1;
 
 
   @CommandLine.Option(
     names = {"--min-num-terms"},
     description = "Minimal number of terms to precompute for."
   )
-  private int minNumTerms = 1;
+  public int minNumTerms = 1;
 
   @CommandLine.Option(
     names = {"--max-num-terms"},
     description = "Maximal number of terms to precompute for."
   )
-  private int maxNumTerms = 20;
+  public int maxNumTerms = 20;
 
   @CommandLine.Option(
     names = {"--num-iterations"},
     description = "Number of iterations to run."
   )
-  private int numIterations = 10_000;
+  public int numIterations = 10_000;
 
   @CommandLine.Option(
     names = {"--seed"},
     description = "Seed to use for RNG."
   )
-  private int seed = 42;
+  public int seed = 42;
 
   @CommandLine.Option(
     names = {"--input-obo-file"},
     description = "Path to (HPO) OBO file to load.",
     required = true
   )
-  private String oboFile;
+  public String oboFile;
 
   @CommandLine.Option(
     names = {"--gene-to-term-file"},
     description = "Path to gene-to-term link file.",
     required = true
   )
-  private String geneToTermLinkFile;
+  public String geneToTermLinkFile;
 
   @CommandLine.Option(
     names = {"--output-score-dist"},
     description = "Path to output score distribution file",
     required = true
   )
-  private String outputScoreDistFile;
+  public String outputScoreDistFile;
 
   /** @return Return number of threads to use. */
   public int getNumThreads() {

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/MicaCalculator.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/MicaCalculator.java
@@ -1,0 +1,66 @@
+package org.monarchinitiative.phenol.cli.demo;
+
+import org.monarchinitiative.phenol.annotations.constants.hpo.HpoSubOntologyRootTermIds;
+import org.monarchinitiative.phenol.annotations.formats.hpo.AnnotatedItem;
+import org.monarchinitiative.phenol.annotations.formats.hpo.AnnotatedItemContainer;
+import org.monarchinitiative.phenol.ontology.data.Identified;
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.monarchinitiative.phenol.ontology.data.TermIds;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Class for calculating information content of the <em>most informative common ancestor</em> (MICA)
+ * for {@link Ontology} concepts using a corpus of annotated.
+ */
+public class MicaCalculator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MicaCalculator.class);
+
+  private final Ontology hpo;
+
+  public MicaCalculator(Ontology hpo) {
+    this.hpo = Objects.requireNonNull(hpo);
+  }
+
+  public MicaData calculateMica(AnnotatedItemContainer<? extends AnnotatedItem> itemContainer) {
+    Instant start = Instant.now();
+    Map<TermId, Integer> phenotypeIdToDiseaseIds = new HashMap<>();
+    Map<TermId, Collection<TermId>> diseaseIdToTermIds = new HashMap<>();
+
+    for (AnnotatedItem item: itemContainer) {
+      List<TermId> annotationTermIds = item.annotations().stream()
+        .map(Identified::id)
+        .collect(Collectors.toList());
+      // add term ancestors
+      Set<TermId> inclAncestorTermIds = TermIds.augmentWithAncestors(hpo, annotationTermIds, true);
+
+      for (TermId tid : inclAncestorTermIds) {
+        phenotypeIdToDiseaseIds.compute(tid, (key, val) -> val == null ? 0 : val + 1);
+        diseaseIdToTermIds.computeIfAbsent(item.id(), key -> new HashSet<>()).add(tid); // Note that this MUST be a Set
+      }
+    }
+
+    Map<TermId, Double> termToIc = new HashMap<>();
+    int totalPopulationHpoTerms = phenotypeIdToDiseaseIds.get(HpoSubOntologyRootTermIds.PHENOTYPIC_ABNORMALITY);
+    for (Map.Entry<TermId, Integer> e : phenotypeIdToDiseaseIds.entrySet()) {
+      int annotatedCount = e.getValue();
+      double ic = -1 * Math.log((double)annotatedCount/totalPopulationHpoTerms);
+      termToIc.put(e.getKey(), ic);
+    }
+
+    Duration duration = Duration.between(start, Instant.now());
+    long seconds = duration.toMillis() / 1000;
+    double ms = (double) duration.toMillis() % 1000;
+    LOGGER.debug("Calculated information content in {}s {}us", seconds, ms);
+
+    return new MicaData(diseaseIdToTermIds, phenotypeIdToDiseaseIds, termToIc);
+  }
+
+}

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/MicaCalculator.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/MicaCalculator.java
@@ -24,8 +24,14 @@ public class MicaCalculator {
   private static final Logger LOGGER = LoggerFactory.getLogger(MicaCalculator.class);
 
   private final Ontology hpo;
+  private final boolean assumeAnnotated;
 
   public MicaCalculator(Ontology hpo) {
+    this(hpo, false);
+  }
+
+  public MicaCalculator(Ontology hpo, boolean assumeAnnotated) {
+    this.assumeAnnotated = assumeAnnotated;
     this.hpo = Objects.requireNonNull(hpo);
   }
 
@@ -50,7 +56,7 @@ public class MicaCalculator {
     Map<TermId, Double> termToIc = new HashMap<>();
     int totalPopulationHpoTerms = phenotypeIdToDiseaseIds.get(HpoSubOntologyRootTermIds.PHENOTYPIC_ABNORMALITY);
     for (Map.Entry<TermId, Integer> e : phenotypeIdToDiseaseIds.entrySet()) {
-      int annotatedCount = e.getValue();
+      int annotatedCount = assumeAnnotated ? Math.max(e.getValue(), 1) : e.getValue();
       double ic = -1 * Math.log((double)annotatedCount/totalPopulationHpoTerms);
       termToIc.put(e.getKey(), ic);
     }

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/MicaData.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/MicaData.java
@@ -1,0 +1,35 @@
+package org.monarchinitiative.phenol.cli.demo;
+
+import org.monarchinitiative.phenol.ontology.data.TermId;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class MicaData {
+
+  private final Map<TermId, Collection<TermId>> diseaseIdToTermIds;
+  // Number of diseases the term is observed in.
+  private final Map<TermId, Integer> phenotypeIdToDiseaseIds;
+
+  private final Map<TermId, Double> termToIc;
+
+  public MicaData(Map<TermId, Collection<TermId>> diseaseIdToTermIds,
+                  Map<TermId, Integer> phenotypeIdToDiseaseIds, Map<TermId, Double> termToIc) {
+    this.diseaseIdToTermIds = diseaseIdToTermIds;
+    this.phenotypeIdToDiseaseIds = phenotypeIdToDiseaseIds;
+    this.termToIc = termToIc;
+  }
+
+  public Map<TermId, Collection<TermId>> diseaseIdToTermIds() {
+    return diseaseIdToTermIds;
+  }
+
+  public Map<TermId, Integer> phenotypeIdToDiseaseIds() {
+    return phenotypeIdToDiseaseIds;
+  }
+
+  public Map<TermId, Double> termToIc() {
+    return termToIc;
+  }
+
+}

--- a/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/ResnikGeneBasedHpoDemo.java
+++ b/phenol-cli/src/main/java/org/monarchinitiative/phenol/cli/demo/ResnikGeneBasedHpoDemo.java
@@ -1,7 +1,6 @@
 package org.monarchinitiative.phenol.cli.demo;
 
 import org.monarchinitiative.phenol.annotations.assoc.GeneInfoGeneType;
-import org.monarchinitiative.phenol.annotations.constants.hpo.HpoSubOntologyRootTermIds;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoAssociationData;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoDisease;
 import org.monarchinitiative.phenol.annotations.formats.hpo.HpoDiseases;
@@ -11,7 +10,6 @@ import org.monarchinitiative.phenol.annotations.io.hpo.HpoDiseaseLoaders;
 import org.monarchinitiative.phenol.io.OntologyLoader;
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.monarchinitiative.phenol.ontology.data.TermId;
-import org.monarchinitiative.phenol.ontology.data.TermIds;
 import org.monarchinitiative.phenol.ontology.similarity.HpoResnikSimilarity;
 
 import java.io.IOException;
@@ -52,7 +50,7 @@ public class ResnikGeneBasedHpoDemo {
     System.out.println("[INFO] geneIdToSymbolMap with " + geneIdToSymbolMap.size() + " entries");
 
     // Compute list of annotations and mapping from OMIM ID to term IDs.
-    MicaCalculator calculator = new MicaCalculator(hpo);
+    MicaCalculator calculator = new MicaCalculator(hpo, false);
     MicaData micaData = calculator.calculateMica(hpoDiseases);
     diseaseIdToTermIds = micaData.diseaseIdToTermIds();
     termToIc = micaData.termToIc();

--- a/phenol-cli/src/main/resources/logback.xml
+++ b/phenol-cli/src/main/resources/logback.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="pattern" value="%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+
+    <!-- We write INFO and above events to console. -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <encoder>
+            <pattern>${pattern}</pattern>
+        </encoder>
+    </appender>
+
+    <root>
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/TermIds.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/TermIds.java
@@ -1,5 +1,7 @@
 package org.monarchinitiative.phenol.ontology.data;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -20,8 +22,9 @@ public final class TermIds {
    * @param includeRoot Whether or not to include the root.
    * @return Augmented version of {@code termIds} (not a copy) with ancestors of all elements.
    */
-  public static Set<TermId> augmentWithAncestors(Ontology ontology, Set<TermId> termIds, boolean includeRoot) {
-    termIds.addAll(ontology.getAllAncestorTermIds(termIds, includeRoot));
-    return termIds;
+  public static Set<TermId> augmentWithAncestors(Ontology ontology, Collection<TermId> termIds, boolean includeRoot) {
+    Set<TermId> augmented = new HashSet<>(termIds);
+    augmented.addAll(ontology.getAllAncestorTermIds(termIds, includeRoot));
+    return augmented;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <jgrapht.version>1.5.1</jgrapht.version>
     <slf4j.version>1.7.32</slf4j.version>
     <commons-codec.version>1.15</commons-codec.version>
+    <commons-csv.version>1.9.0</commons-csv.version>
     <h2.version>1.4.200</h2.version>
     <picocli.version>4.6.3</picocli.version>
 
@@ -152,9 +153,19 @@
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-csv</artifactId>
+        <version>${commons-csv.version}</version>
+      </dependency>
+      <dependency>
         <groupId>info.picocli</groupId>
         <artifactId>picocli</artifactId>
         <version>${picocli.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>1.4.3</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Add `precompute-resnik` command to prepare a table of MICA IC values for HPO term pairs starting from `hp.json` and `phenotype.hpoa`.