### PR TITLE
Allow dropping non-propagating relationships during ontology loading

### DIFF
--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/algo/OntologyAlgorithmTest.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/algo/OntologyAlgorithmTest.java
@@ -13,6 +13,16 @@ import static org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm.*;
 
 public class OntologyAlgorithmTest {
 
+  /*
+     The example graph:
+                  id5
+                 ^ ^ ^
+                /  |  \
+              id2 id3 id4
+                ^  ^  ^
+                 \ | /
+                  id1
+   */
   private ImmutableOntology ontology;
 
   private TermId id1;

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/OntologyLoader.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/OntologyLoader.java
@@ -53,16 +53,31 @@ public class OntologyLoader {
   }
 
   public static Ontology loadOntology(InputStream inputStream, CurieUtil curieUtil, String... termIdPrefixes) {
+    return loadOntology(inputStream, curieUtil, OntologyLoaderOptions.defaultOptions(), termIdPrefixes);
+  }
+
+  public static Ontology loadOntology(InputStream inputStream,
+                                      CurieUtil curieUtil,
+                                      OntologyLoaderOptions options,
+                                      String... termIdPrefixes) {
     GraphDocument graphDocument = loadGraphDocument(inputStream);
-    return loadOntology(graphDocument, curieUtil, termIdPrefixes);
+    return loadOntology(graphDocument, curieUtil, options, termIdPrefixes);
   }
 
   public static Ontology loadOntology(GraphDocument graphDocument, CurieUtil curieUtil, String... termIdPrefixes) {
+    return loadOntology(graphDocument, curieUtil, OntologyLoaderOptions.defaultOptions(), termIdPrefixes);
+  }
+
+  public static Ontology loadOntology(GraphDocument graphDocument,
+                                      CurieUtil curieUtil,
+                                      OntologyLoaderOptions options,
+                                      String... termIdPrefixes) {
     logger.debug("Finished loading ontology");
     logger.debug("Creating phenol ontology");
     OboGraphDocumentAdaptor graphDocumentAdaptor = OboGraphDocumentAdaptor.builder()
       .curieUtil(curieUtil)
       .wantedTermIdPrefixes(Set.of(termIdPrefixes))
+      .discardNonPropagatingRelationships(options.discardNonPropagatingRelationships())
       .build(graphDocument);
 
     Ontology ontology = graphDocumentAdaptor.buildOntology();
@@ -71,8 +86,8 @@ public class OntologyLoader {
   }
 
   private static GraphDocument loadGraphDocument(File file) {
-    try {
-      return loadGraphDocument(new FileInputStream(file));
+    try (InputStream is = new BufferedInputStream(new FileInputStream(file))){
+      return loadGraphDocument(is);
     } catch (IOException e) {
       throw new PhenolRuntimeException("Unable to load ontology", e);
     }

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/OntologyLoaderOptions.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/OntologyLoaderOptions.java
@@ -1,0 +1,55 @@
+package org.monarchinitiative.phenol.io;
+
+import java.util.Objects;
+
+/**
+ * A record-like class with options for parameterizing the ontology loader process.
+ *
+ * @see OntologyLoader
+ */
+public class OntologyLoaderOptions {
+
+  private static final OntologyLoaderOptions DEFAULT_OPTIONS = new OntologyLoaderOptions(false);
+
+  /**
+   * @return options that keep non-propagating relationships
+   * in the {@link org.monarchinitiative.phenol.ontology.data.Ontology} graph.
+   */
+  public static OntologyLoaderOptions defaultOptions() {
+    return DEFAULT_OPTIONS;
+  }
+
+  public static OntologyLoaderOptions of(boolean discardNonPropagatingRelationships) {
+    return new OntologyLoaderOptions(discardNonPropagatingRelationships);
+  }
+
+  private final boolean discardNonPropagatingRelationships;
+
+  private OntologyLoaderOptions(boolean discardNonPropagatingRelationships) {
+    this.discardNonPropagatingRelationships = discardNonPropagatingRelationships;
+  }
+
+  public boolean discardNonPropagatingRelationships() {
+    return discardNonPropagatingRelationships;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    OntologyLoaderOptions that = (OntologyLoaderOptions) o;
+    return discardNonPropagatingRelationships == that.discardNonPropagatingRelationships;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(discardNonPropagatingRelationships);
+  }
+
+  @Override
+  public String toString() {
+    return "OntologyLoaderOptions{" +
+      "discardNonPropagatingRelationships=" + discardNonPropagatingRelationships +
+      '}';
+  }
+}

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obographs/OboGraphDocumentAdaptor.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obographs/OboGraphDocumentAdaptor.java
@@ -69,6 +69,8 @@ public class OboGraphDocumentAdaptor {
     private Map<String, String> metaInfo;
     private List<Term> terms;
     private List<Relationship> relationships;
+    // An option used for discarding non-propagating relationships during loading.
+    private boolean discardNonPropagatingRelationships = false;
 
     public Builder curieUtil(CurieUtil curieUtil) {
       Objects.requireNonNull(curieUtil);
@@ -79,6 +81,11 @@ public class OboGraphDocumentAdaptor {
     public Builder wantedTermIdPrefixes(Set<String> wantedTermIdPrefixes) {
       Objects.requireNonNull(wantedTermIdPrefixes);
       this.wantedTermIdPrefixes = wantedTermIdPrefixes;
+      return this;
+    }
+
+    public Builder discardNonPropagatingRelationships(boolean value) {
+      this.discardNonPropagatingRelationships = value;
       return this;
     }
 
@@ -222,6 +229,10 @@ public class OboGraphDocumentAdaptor {
 
         if (subjectTermId != null && objectTermId != null) {
           RelationshipType relType = RelationshipType.of(edge.getPred(), propertyIdLabels.getOrDefault(edge.getPred(), "unknown"));
+          if (discardNonPropagatingRelationships && !relType.propagates())
+            // The user decided to drop non-propagating relationships.
+            continue;
+
           Relationship relationship = new Relationship(subjectTermId, objectTermId, edgeId++, relType);
           relationshipsList.add(relationship);
         }


### PR DESCRIPTION
For specific applications, it is desirable to only keep the propagating relationships in the ontology graph. However, the current code includes relationships of all types by default.

This PR adds an option for dropping non-propagating relationships during the ontology parsing. An `OntologyLoaderOptions` class is added to `phenol-io` that can be used in `OntologyLoader.loadOntology(...)`:
```
public static Ontology loadOntology(InputStream inputStream,
                                    CurieUtil curieUtil,
                                    OntologyLoaderOptions options,
                                    String... termIdPrefixes) {
  ...
}
```

This is a non-breaking change and the default loading is unaffected. However, if desired, the user can choose to drop the unwanted non-propagating relationships from the ontology graph.

As a second item, the PR addresses an inconsistency, where `OntologyAlgorithm.getParentTerms()` considered relationship propagation when fetching parent term IDs, but the symmetric function `OntologyAlgorithm.getChildTerms()` did not consider the propagation aspect. Now, both functions consider the propagation.