### PR TITLE
obsoleting classes used for the small files and not needed for phenol…

### DIFF
--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationAlgorithms.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationAlgorithms.java
@@ -16,6 +16,7 @@ import static org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm.getAn
  * and import into {@link HpoDisease} objects).
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  */
+@Deprecated(forRemoval = true)
 public class HpoAnnotationAlgorithms {
 
   /**

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationEntry.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationEntry.java
@@ -33,6 +33,7 @@ import static org.monarchinitiative.phenol.annotations.constants.hpo.HpoOnsetTer
  *
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  */
+@Deprecated(forRemoval = true)
 public class HpoAnnotationEntry {
   private final static Logger logger = LoggerFactory.getLogger(HpoAnnotationEntry.class);
   // To match e.g. 10/20
@@ -627,7 +628,7 @@ public class HpoAnnotationEntry {
     } else {
       TermId current = ontology.getTermMap().get(id).id();
       if (!current.equals(id)) {
-        throw new ObsoleteTermIdException(String.format("Usage of (obsolete) alt_id %s for %s (%s)",
+        throw new ObsoleteTermIdRuntimeException(String.format("Usage of (obsolete) alt_id %s for %s (%s)",
           id.getValue(),
           current.getValue(),
           ontology.getTermMap().get(id).getName()));
@@ -665,7 +666,7 @@ public class HpoAnnotationEntry {
     }
     TermId current = ontology.getTermMap().get(tid).id();
     if (!current.equals(tid)) {
-      throw new ObsoleteTermIdException(String.format("Usage of (obsolete) alt_id %s for %s (%s)",
+      throw new ObsoleteTermIdRuntimeException(String.format("Usage of (obsolete) alt_id %s for %s (%s)",
         tid.getValue(),
         current.getValue(),
         ontology.getTermMap().get(tid).getName()));

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationFileIngestor.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationFileIngestor.java
@@ -21,6 +21,7 @@ import java.util.*;
  *
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  */
+@Deprecated(forRemoval = true)
 public class HpoAnnotationFileIngestor {
   /**
    * Reference to the HPO object.

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationFileParser.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationFileParser.java
@@ -1,9 +1,5 @@
 package org.monarchinitiative.phenol.annotations.hpo;
 
-import org.monarchinitiative.phenol.annotations.hpo.HpoAnnotationEntry;
-import org.monarchinitiative.phenol.annotations.hpo.HpoAnnotationModel;
-import org.monarchinitiative.phenol.annotations.hpo.HpoAnnotationModelException;
-import org.monarchinitiative.phenol.annotations.hpo.ObsoleteTermIdException;
 import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.slf4j.Logger;
@@ -25,6 +21,7 @@ import java.util.*;
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  * Created by peter on 2/05/2018.
  */
+@Deprecated(forRemoval = true)
 public class HpoAnnotationFileParser {
   private final static Logger logger = LoggerFactory.getLogger(OrphanetXML2HpoDiseaseModelParser.class);
   /**
@@ -98,7 +95,7 @@ public class HpoAnnotationFileParser {
         try {
           HpoAnnotationEntry entry = HpoAnnotationEntry.fromLine(line, ontology);
           entryList.add(entry);
-        } catch (ObsoleteTermIdException obsE) {
+        } catch (ObsoleteTermIdRuntimeException obsE) {
           // try to rescue obsolete termid!
           Optional<HpoAnnotationEntry> entryOpt = HpoAnnotationEntry.fromLineReplaceObsoletePhenotypeData(line, ontology);
           entryOpt.ifPresent(entryList::add);

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationModel.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationModel.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  * Created by peter on 1/20/2018.
  */
+@Deprecated(forRemoval = true)
 public class HpoAnnotationModel {
   /**
    * The base name of the HPO Annotation file.

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationModelException.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationModelException.java
@@ -8,6 +8,7 @@ import org.monarchinitiative.phenol.base.PhenolException;
  * {@link org.monarchinitiative.phenol.annotations.hpo.HpoAnnotationEntry} (single line of an HPO annotation file)
  * @author Peter Robinson
  */
+@Deprecated(forRemoval = true)
 public class HpoAnnotationModelException extends PhenolException {
   private final static long serialVersionUID = 2;
     public HpoAnnotationModelException(String msg) {super(msg);}

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/ObsoleteTermIdException.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/ObsoleteTermIdException.java
@@ -1,6 +1,0 @@
-package org.monarchinitiative.phenol.annotations.hpo;
-
-public class ObsoleteTermIdException extends HpoAnnotationModelException {
-  private final static long serialVersionUID = 2;
-    public ObsoleteTermIdException(String msg) {super(msg);}
-}

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/ObsoleteTermIdRuntimeException.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/ObsoleteTermIdRuntimeException.java
@@ -1,0 +1,12 @@
+package org.monarchinitiative.phenol.annotations.hpo;
+
+
+import org.monarchinitiative.phenol.base.PhenolRuntimeException;
+
+/**
+ * TODO check for obsoleted primary term ids when parsing phenotype.hpoa
+ */
+public class ObsoleteTermIdRuntimeException extends PhenolRuntimeException  {
+  private final static long serialVersionUID = 2;
+    public ObsoleteTermIdRuntimeException(String msg) {super(msg);}
+}

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/OrphanetInheritanceXMLParser.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/OrphanetInheritanceXMLParser.java
@@ -17,6 +17,7 @@ import java.util.*;
 
 import static org.monarchinitiative.phenol.annotations.constants.hpo.HpoModeOfInheritanceTermIds.*;
 
+@Deprecated(forRemoval = true)
 public class OrphanetInheritanceXMLParser {
   /**
    * Path to {@code en_product9_age.xml} file.

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/OrphanetXML2HpoDiseaseModelParser.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/OrphanetXML2HpoDiseaseModelParser.java
@@ -54,6 +54,7 @@ import javax.xml.stream.events.XMLEvent;
  *
  * @author Peter Robinson
  */
+@Deprecated(forRemoval = true)
 public class OrphanetXML2HpoDiseaseModelParser {
   private final static Logger logger = LoggerFactory.getLogger(OrphanetXML2HpoDiseaseModelParser.class);
   /**

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/PhenotypeDotHpoaFileWriter.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/hpo/PhenotypeDotHpoaFileWriter.java
@@ -19,6 +19,7 @@ import java.util.*;
  *
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  */
+@Deprecated(forRemoval = true)
 public class PhenotypeDotHpoaFileWriter {
   private final static Logger logger = LoggerFactory.getLogger(PhenotypeDotHpoaFileWriter.class);
   /**


### PR DESCRIPTION
… public library. Moved to [hpoAnnotQc](https://github.com/monarch-initiative/hpoannotqc).
The deprecated classes can be deleted unless something speaks against this.