### PR TITLE
Setup serialization of `Identified` concepts

### DIFF
--- a/phenol-analysis/pom.xml
+++ b/phenol-analysis/pom.xml
@@ -26,6 +26,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <version>${h2.version}</version>

--- a/phenol-core/pom.xml
+++ b/phenol-core/pom.xml
@@ -19,6 +19,11 @@
       <artifactId>jgrapht-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <scope>test</scope>

--- a/phenol-core/src/main/java/module-info.java
+++ b/phenol-core/src/main/java/module-info.java
@@ -8,5 +8,6 @@ module org.monarchinitiative.phenol.core {
   exports org.monarchinitiative.phenol.utils;
 
   requires transitive org.jgrapht.core; // due to DefaultDirectedGraph being exposed in MinimalOntology
+  requires com.fasterxml.jackson.databind; // for annotating model classes
   requires org.slf4j;
 }

--- a/phenol-core/src/main/java/module-info.java
+++ b/phenol-core/src/main/java/module-info.java
@@ -10,4 +10,7 @@ module org.monarchinitiative.phenol.core {
   requires transitive org.jgrapht.core; // due to DefaultDirectedGraph being exposed in MinimalOntology
   requires com.fasterxml.jackson.databind; // for annotating model classes
   requires org.slf4j;
+
+  // To enable custom `TermId` serialization
+  opens org.monarchinitiative.phenol.ontology.serialize;
 }

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Identified.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Identified.java
@@ -2,8 +2,6 @@ package org.monarchinitiative.phenol.ontology.data;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.monarchinitiative.phenol.ontology.serialize.TermIdSerializer;
 
 /**
  * The interface implemented by entities that have an identifier.
@@ -11,7 +9,6 @@ import org.monarchinitiative.phenol.ontology.serialize.TermIdSerializer;
 public interface Identified {
 
   @JsonGetter
-  @JsonSerialize(using = TermIdSerializer.class)
   TermId id();
 
   /**

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Identified.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Identified.java
@@ -2,6 +2,8 @@ package org.monarchinitiative.phenol.ontology.data;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.monarchinitiative.phenol.ontology.serialize.TermIdSerializer;
 
 /**
  * The interface implemented by entities that have an identifier.
@@ -9,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public interface Identified {
 
   @JsonGetter
+  @JsonSerialize(using = TermIdSerializer.class)
   TermId id();
 
   /**

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Identified.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/Identified.java
@@ -1,16 +1,21 @@
 package org.monarchinitiative.phenol.ontology.data;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * The interface implemented by entities that have an identifier.
  */
 public interface Identified {
 
+  @JsonGetter
   TermId id();
 
   /**
    * @deprecated the getter will be removed in <code>v3.0.0</code>, use {@link #id()} instead.
    */
   @Deprecated(forRemoval = true, since = "2.0.0-RC2")
+  @JsonIgnore
   default TermId getId() {
     return id();
   }

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/TermId.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/TermId.java
@@ -1,5 +1,7 @@
 package org.monarchinitiative.phenol.ontology.data;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.monarchinitiative.phenol.base.PhenolRuntimeException;
 
 import java.io.Serializable;
@@ -60,14 +62,17 @@ public final class TermId implements Comparable<TermId>, Serializable {
     this.value = termId;
   }
 
+  @JsonIgnore
   public String getPrefix() {
     return value.substring(0, separatorPos);
   }
 
+  @JsonIgnore
   public String getId() {
     return value.substring(separatorPos + 1);
   }
 
+  @JsonGetter
   public String getValue() {
     return value;
   }

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/TermId.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/TermId.java
@@ -1,8 +1,8 @@
 package org.monarchinitiative.phenol.ontology.data;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.monarchinitiative.phenol.base.PhenolRuntimeException;
+import org.monarchinitiative.phenol.ontology.serialize.TermIdSerializer;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -13,6 +13,7 @@ import java.util.Objects;
  * @author <a href="mailto:manuel.holtgrewe@bihealth.de">Manuel Holtgrewe</a>
  * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
  */
+@JsonSerialize(using = TermIdSerializer.class)
 public final class TermId implements Comparable<TermId>, Serializable {
 
   /** Serial UId for serialization. */
@@ -62,17 +63,14 @@ public final class TermId implements Comparable<TermId>, Serializable {
     this.value = termId;
   }
 
-  @JsonIgnore
   public String getPrefix() {
     return value.substring(0, separatorPos);
   }
 
-  @JsonIgnore
   public String getId() {
     return value.substring(separatorPos + 1);
   }
 
-  @JsonGetter
   public String getValue() {
     return value;
   }

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/serialize/TermIdSerializer.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/serialize/TermIdSerializer.java
@@ -1,0 +1,27 @@
+package org.monarchinitiative.phenol.ontology.serialize;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+
+import java.io.IOException;
+
+/**
+ * Serialize the {@link TermId}'s {@code value} as a {@link String}.
+ */
+public class TermIdSerializer extends StdSerializer<TermId> {
+
+  public TermIdSerializer() {
+    super(TermId.class);
+  }
+
+  public TermIdSerializer(StdSerializer<?> src) {
+    super(src);
+  }
+
+  @Override
+  public void serialize(TermId id, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+    jsonGenerator.writeString(id.getValue());
+  }
+}

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/data/IdentifiedTest.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/data/IdentifiedTest.java
@@ -1,0 +1,74 @@
+package org.monarchinitiative.phenol.ontology.data;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class IdentifiedTest {
+
+  /**
+   *
+   * Two-pronged test. First, test that {@link Identified#id()} is serialized as an "id" string field.
+   * Second, test that a list of {@link TermId}s is serialized as a list of string values (NOT JSON objects).
+   */
+  @Test
+  public void testSerialization() throws JsonProcessingException {
+    ObjectMapper mapper = new ObjectMapper();
+
+    Identified id = new SimpleIdentified(
+      TermId.of("BLA:1234567"),
+      List.of(TermId.of("BLA:999"), TermId.of("BLA:888")),
+      "Jimmy",
+      15,
+      true);
+
+
+    String actual = mapper.writeValueAsString(id);
+    assertThat(actual, equalTo("{\"id\":\"BLA:1234567\",\"altTermIds\":[\"BLA:999\",\"BLA:888\"],\"name\":\"Jimmy\",\"age\":15,\"alive\":true}"));
+  }
+
+  public static class SimpleIdentified implements Identified {
+
+    private final TermId id;
+    private final List<TermId> altTermIds;
+    private final String name;
+    private final int age;
+    private final boolean alive;
+
+    private SimpleIdentified(TermId id, List<TermId> altTermIds, String name, int age, boolean alive) {
+      this.id = id;
+      this.altTermIds = altTermIds;
+      this.name = name;
+      this.age = age;
+      this.alive = alive;
+    }
+
+
+    @Override
+    public TermId id() {
+      return id;
+    }
+
+    public List<TermId> getAltTermIds() {
+      return altTermIds;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public int getAge() {
+      return age;
+    }
+
+    public boolean isAlive() {
+      return alive;
+    }
+  }
+
+}

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/data/ImmutableTermIdTest.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/ontology/data/ImmutableTermIdTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.monarchinitiative.phenol.base.PhenolRuntimeException;
 
@@ -58,6 +59,16 @@ public class ImmutableTermIdTest {
     assertEquals("HP", termId.getPrefix());
     assertEquals("0000001", termId.getId());
     assertEquals("HP:0000001", termId.getValue());
+  }
+
+  /**
+   * Check that the `TermId` is serialized into a simple quoted string and NOT into a JSON object.
+   */
+  @Test
+  public void testSerializeToJson() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    assertEquals("\"HP:0000001\"", mapper.writeValueAsString(termId));
+    assertEquals("\"HP:0000002\"", mapper.writeValueAsString(termId2));
   }
 
   @Test

--- a/phenol-io/pom.xml
+++ b/phenol-io/pom.xml
@@ -25,16 +25,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>--add-reads com.fasterxml.jackson.datatype.guava=ALL-UNNAMED </argLine>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
 
   <name>Phenol</name>
 
-  <description>Phenotype Ontology Library: phenol</description>
-  <url>https://github.com/monarchinitiative/phenol</url>
+  <description>Phenotype Ontology Library</description>
+  <url>https://github.com/monarch-initiative/phenol</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.1.0</version>
         </plugin>
 
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
     <obographs.version>0.3.0</obographs.version>
-    <jackson.version>2.12.1</jackson.version>
+    <jackson.version>2.14.3</jackson.version>
     <guava.version>30.1-jre</guava.version>
     <jgrapht.version>1.5.1</jgrapht.version>
     <slf4j.version>1.7.32</slf4j.version>
@@ -146,6 +146,11 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
Add `jackson-databind` in a provided scope and annotate `Identified` with Jackson annotations to unify the serialization. Consequently, an `Identified` entity will serialize the `id` attribute as well as any other attributes that return a single `TermId` or a collection of `TermId`s  as string(s) and *NOT* as JSON objects.

For instance, a `Term` will turn into something like:

```
{
  "id": "HP:1234567",
  "altTermIds": ["HP:111", "HP:222"]
  // the remaining fields
}
```