### PR TITLE
Require `MinimalOntology` instead of `Ontology` in `phenol-annotations`.

### DIFF
--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoAssociationData.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoAssociationData.java
@@ -3,7 +3,7 @@ package org.monarchinitiative.phenol.annotations.formats.hpo;
 import org.monarchinitiative.phenol.annotations.formats.GeneIdentifier;
 import org.monarchinitiative.phenol.annotations.formats.GeneIdentifiers;
 import org.monarchinitiative.phenol.ontology.data.Identified;
-import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.MinimalOntology;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
 import java.util.Collection;
@@ -29,7 +29,7 @@ public interface HpoAssociationData {
    * @return a builder for building {@link HpoAssociationData}.
    * @see HpoAssociationDataBuilder
    */
-  static HpoAssociationDataBuilder builder(Ontology hpo) {
+  static HpoAssociationDataBuilder builder(MinimalOntology hpo) {
     return new HpoAssociationDataBuilder(hpo);
   }
 

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoAssociationDataBuilder.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoAssociationDataBuilder.java
@@ -35,7 +35,7 @@ public class HpoAssociationDataBuilder {
   private static final Logger LOGGER = LoggerFactory.getLogger(HpoAssociationDataBuilder.class);
 
   // Ontology
-  private final Ontology hpo;
+  private final MinimalOntology hpo;
 
   // GeneIdentifierLoader
   private Path homoSapiensGeneInfoPath;
@@ -53,7 +53,7 @@ public class HpoAssociationDataBuilder {
   private AnnotatedItemContainer<? extends AnnotatedItem> diseases;
   private HpoGeneAnnotations hpoGeneAnnotations;
 
-  HpoAssociationDataBuilder(Ontology hpo) {
+  HpoAssociationDataBuilder(MinimalOntology hpo) {
     // private no-op
     this.hpo = Objects.requireNonNull(hpo);
   }

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDisease.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDisease.java
@@ -6,7 +6,7 @@ import org.monarchinitiative.phenol.annotations.base.temporal.TemporalInterval;
 import org.monarchinitiative.phenol.annotations.io.hpo.HpoAnnotationLine;
 import org.monarchinitiative.phenol.base.PhenolRuntimeException;
 import org.monarchinitiative.phenol.ontology.data.Identified;
-import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.MinimalOntology;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
 import java.util.*;
@@ -172,13 +172,10 @@ public interface HpoDisease extends AnnotatedItem {
    * @param hpo HPO ontology.
    * @return true iff this disease is annotated to the term directly or via annotation propagation.
    */
-  default boolean isAnnotatedTo(TermId termId, Ontology hpo) {
-    List<TermId> directAnnotations = presentAnnotationsStream()
-      .map(Identified::id)
-      .collect(Collectors.toList());
-    Set<TermId> ancestors = hpo.getAllAncestorTermIds(directAnnotations, true);
-
-    return ancestors.contains(termId);
+  default boolean isAnnotatedTo(TermId termId, MinimalOntology hpo) {
+    return presentAnnotationsStream()
+      .flatMap(a -> hpo.graph().getAncestorsStream(a.id(), true))
+      .anyMatch(termId::equals);
   }
 
   /**

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseDefault.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/HpoDiseaseDefault.java
@@ -1,7 +1,7 @@
 package org.monarchinitiative.phenol.annotations.formats.hpo;
 
 import org.monarchinitiative.phenol.annotations.base.temporal.TemporalInterval;
-import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.MinimalOntology;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
 import java.util.*;
@@ -113,7 +113,7 @@ class HpoDiseaseDefault implements HpoDisease {
    * @param ontology Reference to the HPO ontology
    * @return frequency of the term in the disease (including annotation propagation)
    */
-  private double getFrequencyOfTermInDiseaseWithAnnotationPropagation(TermId tid, Ontology ontology) {
+  private double getFrequencyOfTermInDiseaseWithAnnotationPropagation(TermId tid, MinimalOntology ontology) {
 //    return getPhenotypicAbnormalityTermIds()
 //      .map(term -> {
 //        Set<TermId> ancs = ontology.getAncestorTermIds(term, true);

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/category/HpoCategoryMap.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/hpo/category/HpoCategoryMap.java
@@ -2,7 +2,7 @@ package org.monarchinitiative.phenol.annotations.formats.hpo.category;
 
 
 import org.monarchinitiative.phenol.base.PhenolRuntimeException;
-import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.MinimalOntology;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 import org.slf4j.Logger;
@@ -18,7 +18,7 @@ import static org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm.getPa
  * <p>
  * <p>
  * The main function takes a list of HPO terms and returns a compatible list but sorted according to the
- * categories. Client code should use {@link #addAnnotatedTerms(List, Ontology)}  to initialize the
+ * categories. Client code should use {@link #addAnnotatedTerms(List, org.monarchinitiative.phenol.ontology.data.MinimalOntology)}  to initialize the
  * Category map. The function {@link #getActiveCategoryList()} returns an immutable list of categories
  * that include at least one HPO term used for annotation.
  * </p>
@@ -170,7 +170,7 @@ public class HpoCategoryMap {
    * @param ontology reference to HPO ontology object
    * @throws PhenolRuntimeException if we try to add an invalid term (i.e., that does not correspond to a category).
    */
-  public void addAnnotatedTerm(TermId tid, Ontology ontology) throws PhenolRuntimeException {
+  public void addAnnotatedTerm(TermId tid, MinimalOntology ontology) throws PhenolRuntimeException {
       HpoCategory cat = getCategory(tid, ontology);
       if (cat == null) {
         LOGGER.warn("Could not get upper level HPO category for "
@@ -181,12 +181,12 @@ public class HpoCategoryMap {
   }
 
   /**
-   * Add a list of {@link TermId} objects using the method {@link #addAnnotatedTerm(TermId, Ontology)}
+   * Add a list of {@link TermId} objects using the method {@link #addAnnotatedTerm(TermId, MinimalOntology)}
    *
    * @param tidlist  list of HPO terms to be added
    * @param ontology reference to HPO ontology object
    */
-  public void addAnnotatedTerms(List<TermId> tidlist, Ontology ontology) {
+  public void addAnnotatedTerms(List<TermId> tidlist, MinimalOntology ontology) {
     for (TermId tid : tidlist) {
       addAnnotatedTerm(tid, ontology);
     }
@@ -199,14 +199,13 @@ public class HpoCategoryMap {
    * @param childTermId TermId for which we will find the category or categories
    * @return an immutable Set of all category ids for childTermId
    */
-  private Set<TermId> getAncestorCategories(Ontology ontology, TermId childTermId) {
+  private Set<TermId> getAncestorCategories(MinimalOntology ontology, TermId childTermId) {
     Set<TermId> builder = new HashSet<>();
     Deque<TermId> stack = new ArrayDeque<>();
     stack.push(childTermId);
     while (!stack.isEmpty()) {
       TermId tid = stack.pop();
-      Set<TermId> parents = getParentTerms(ontology, tid, false);
-      for (TermId p : parents) {
+      for (TermId p : ontology.graph().getParents(tid, false)) {
         if (categorymap.containsKey(p)) {
           builder.add(p);
         } else {
@@ -222,7 +221,7 @@ public class HpoCategoryMap {
    * Identify the category that best matches the term id (usually just
    * find the category that represents an ancestor term).
    */
-  private HpoCategory getCategory(TermId tid, Ontology ontology) {
+  private HpoCategory getCategory(TermId tid, MinimalOntology ontology) {
     if (tid == null) {
       LOGGER.warn("Trying to get HPO Category but input TermId was null...");
       return null;

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoader.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoader.java
@@ -13,7 +13,7 @@ import java.util.zip.GZIPInputStream;
 public interface HpoDiseaseLoader {
 
   /**
-   * @deprecated to be removed in v2.0.0, use {@link HpoDiseaseLoaders#defaultLoader(Ontology, HpoDiseaseLoaderOptions)} instead.
+   * @deprecated to be removed in v2.0.0, use {@link HpoDiseaseLoaders#defaultLoader(org.monarchinitiative.phenol.ontology.data.MinimalOntology, HpoDiseaseLoaderOptions)} instead.
    */
   @Deprecated(forRemoval = true)
   static HpoDiseaseLoader of(Ontology hpo) {
@@ -21,7 +21,7 @@ public interface HpoDiseaseLoader {
   }
 
   /**
-   * @deprecated to be removed in v2.0.0, use {@link HpoDiseaseLoaders#defaultLoader(Ontology, HpoDiseaseLoaderOptions)} instead.
+   * @deprecated to be removed in v2.0.0, use {@link HpoDiseaseLoaders#defaultLoader(org.monarchinitiative.phenol.ontology.data.MinimalOntology, HpoDiseaseLoaderOptions)} instead.
    */
   @Deprecated(forRemoval = true)
   static HpoDiseaseLoader of(Ontology hpo, HpoDiseaseLoaderOptions options) {

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaders.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/io/hpo/HpoDiseaseLoaders.java
@@ -1,5 +1,6 @@
 package org.monarchinitiative.phenol.annotations.io.hpo;
 
+import org.monarchinitiative.phenol.ontology.data.MinimalOntology;
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 
 public class HpoDiseaseLoaders {
@@ -14,17 +15,17 @@ public class HpoDiseaseLoaders {
    * @param options loader options. <b>Note</b>: the default options are at {@link HpoDiseaseLoaderOptions#defaultOptions()}).
    * @return default disease loader.
    */
-  public static HpoDiseaseLoader defaultLoader(Ontology hpo, HpoDiseaseLoaderOptions options) {
+  public static HpoDiseaseLoader defaultLoader(MinimalOntology hpo, HpoDiseaseLoaderOptions options) {
     return new HpoDiseaseLoaderDefault(hpo, options);
   }
 
   /**
-   * Get {@link HpoDiseaseLoader} that does not use deprecated APIs and is, therefore, faster than {@link #defaultLoader(Ontology, HpoDiseaseLoaderOptions)}.
+   * Get {@link HpoDiseaseLoader} that does not use deprecated APIs and is, therefore, faster than {@link #defaultLoader(MinimalOntology, HpoDiseaseLoaderOptions)}.
    *
    * @param hpo HPO ontology.
    * @param options loader options. <b>Note</b>: the default options are at {@link HpoDiseaseLoaderOptions#defaultOptions()}).
    * @return v2 disease loader.
-   * @deprecated use {@link #defaultLoader(Ontology, HpoDiseaseLoaderOptions)} instead.
+   * @deprecated use {@link #defaultLoader(MinimalOntology, HpoDiseaseLoaderOptions)} instead.
    */
   @Deprecated(forRemoval = true, since = "2.0.0-RC5")
   public static HpoDiseaseLoader v2(Ontology hpo, HpoDiseaseLoaderOptions options) {

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/ImmutableOntology.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/ImmutableOntology.java
@@ -303,7 +303,7 @@ public class ImmutableOntology implements Ontology {
       RelationshipType isA = RelationshipType.IS_A;
       TermId rootId = OntologyUtils.findRootTermId(terms, relationships, () -> isA);
 
-      OntologyGraph<TermId> ontologyGraph = OntologyGraphBuilders.csrBuilder(Short.class)
+      OntologyGraph<TermId> ontologyGraph = OntologyGraphBuilders.csrBuilder(Long.class)
         .hierarchyRelation(isA)
         .build(rootId, relationships);
 


### PR DESCRIPTION
Relax the requirements for the ontology object needed to load HPOA data.