### PR TITLE
Allow to opt out of the compatibility checks.

### DIFF
--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/impl/SimpleMinimalOntology.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/data/impl/SimpleMinimalOntology.java
@@ -133,43 +133,86 @@ public class SimpleMinimalOntology implements MinimalOntology {
   /**
    * Create a new builder for the {@linkplain SimpleMinimalOntology}.
    *
-   * @return
+   * @return the builder.
    */
   public static Builder builder() {
     return new Builder();
   }
 
+  /**
+   * Builder for building {@linkplain SimpleMinimalOntology}.
+   */
   public static class Builder {
 
     private RelationshipType hierarchyRelationshipType = RelationshipType.IS_A;
     private Map<String, String> metaInfo = Map.of();
     private final List<Term> terms = new ArrayList<>();
     private final List<Relationship> relationships = new ArrayList<>();
+    private boolean forceBuild = false;
 
     private Builder() {}
 
+    /**
+     * Set the relationship type to be used to represent the ontology hierarchy.
+     *
+     * @param relationshipType a non-null {@linkplain RelationshipType}.
+     * @return the builder.
+     */
     public Builder hierarchyRelationshipType(RelationshipType relationshipType) {
       this.hierarchyRelationshipType = Objects.requireNonNull(relationshipType);
       return this;
     }
 
+    /**
+     * Set the ontology meta information.
+     *
+     * @param metaInfo a non-null {@linkplain Map} with key-value meta information.
+     * @return the builder.
+     */
     public Builder metaInfo(Map<String, String> metaInfo) {
       this.metaInfo = Objects.requireNonNull(metaInfo);
       return this;
     }
 
-    public Builder terms(List<Term> terms) {
+    /**
+     * Set the ontology terms.
+     *
+     * @param terms a non-null {@linkplain Collection} of terms.
+     * @return the builder.
+     */
+    public Builder terms(Collection<? extends Term> terms) {
       this.terms.clear();
       this.terms.addAll(Objects.requireNonNull(terms));
       return this;
     }
 
-    public Builder relationships(List<Relationship> relationships) {
+    /**
+     * Set the ontology relationships.
+     *
+     * @param relationships a non-null {@linkplain Collection} of relationships.
+     * @return the builder.
+     */
+    public Builder relationships(Collection<? extends Relationship> relationships) {
       this.relationships.clear();
       this.relationships.addAll(Objects.requireNonNull(relationships));
       return this;
     }
 
+    /**
+     * Force the build by skipping the compatibility checks.
+     *
+     * @param value {@code true} if the checks should be skipped.
+     * @return the builder.
+     */
+    public Builder forceBuild(boolean value) {
+      this.forceBuild = value;
+      return this;
+    }
+
+    /**
+     * Build the ontology from the provided {@code metaInfo}, {@code terms}, and {@code relationships}.
+     * @return the built {@link SimpleMinimalOntology}.
+     */
     public SimpleMinimalOntology build() {
       // Check if we've got everything we need.
       if (terms.isEmpty())
@@ -202,7 +245,7 @@ public class SimpleMinimalOntology implements MinimalOntology {
       RelationshipContainer relationshipContainer = packageRelationships(relationships);
       TermIdCount termIdCount = new TermIdCount(all, all - nonObsolete, nonObsolete);
 
-      {
+      if (!forceBuild) {
         // Check if the vertices and edges meet the ontology graph requirements.
         List<TermId> vertices = primaryTerms.stream()
           .map(Term::id)

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/MinimalOntologyLoader.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/MinimalOntologyLoader.java
@@ -92,6 +92,7 @@ public class MinimalOntologyLoader {
       .build(graphDocument);
 
     SimpleMinimalOntology ontology = SimpleMinimalOntology.builder()
+      .forceBuild(options.forceBuild())
       .hierarchyRelationshipType(RelationshipType.IS_A)
       .metaInfo(graphDocumentAdaptor.getMetaInfo())
       .terms(graphDocumentAdaptor.getTerms())

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/OntologyLoaderOptions.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/OntologyLoaderOptions.java
@@ -35,37 +35,54 @@ public class OntologyLoaderOptions {
 
   private final boolean discardNonPropagatingRelationships;
   private final boolean discardDuplicatedRelationships;
+  private final boolean forceBuild;
 
   private OntologyLoaderOptions(Builder builder) {
     this.discardNonPropagatingRelationships = builder.discardNonPropagatingRelationships;
     this.discardDuplicatedRelationships = builder.discardDuplicatedRelationships;
+    this.forceBuild = builder.forceBuild;
   }
 
+  /**
+   * @return {@code true} if the non-propagating relationships should be discarded during the ontology build.
+   */
   public boolean discardNonPropagatingRelationships() {
     return discardNonPropagatingRelationships;
   }
 
+  /**
+   * @return {@code true} if the duplicated relationships should be discarded during the ontology build.
+   */
   public boolean discardDuplicatedRelationships() {
     return discardDuplicatedRelationships;
+  }
+
+  /**
+   * @return {@code true} if the ontology build should be forced and {@code false} otherwise.
+   */
+  public boolean forceBuild() {
+    return forceBuild;
   }
 
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    OntologyLoaderOptions that = (OntologyLoaderOptions) o;
-    return discardNonPropagatingRelationships == that.discardNonPropagatingRelationships;
+    OntologyLoaderOptions options = (OntologyLoaderOptions) o;
+    return discardNonPropagatingRelationships == options.discardNonPropagatingRelationships && discardDuplicatedRelationships == options.discardDuplicatedRelationships && forceBuild == options.forceBuild;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(discardNonPropagatingRelationships);
+    return Objects.hash(discardNonPropagatingRelationships, discardDuplicatedRelationships, forceBuild);
   }
 
   @Override
   public String toString() {
     return "OntologyLoaderOptions{" +
       "discardNonPropagatingRelationships=" + discardNonPropagatingRelationships +
+      ", discardDuplicatedRelationships=" + discardDuplicatedRelationships +
+      ", forceBuild=" + forceBuild +
       '}';
   }
 
@@ -75,6 +92,8 @@ public class OntologyLoaderOptions {
   public static class Builder {
     private boolean discardNonPropagatingRelationships = false;
     private boolean discardDuplicatedRelationships = false;
+    private boolean forceBuild = false;
+
 
     private Builder(){}
 
@@ -85,6 +104,17 @@ public class OntologyLoaderOptions {
 
     public Builder discardDuplicatedRelationships(boolean value) {
       this.discardDuplicatedRelationships = value;
+      return this;
+    }
+
+    /**
+     * Force ontology build by skipping compatibility checks.
+     *
+     * @param value {@code true} if the build should be forced, and {@code false} otherwise.
+     * @return the builder.
+     */
+    public Builder forceBuild(boolean value) {
+      this.forceBuild = value;
       return this;
     }
 


### PR DESCRIPTION
Allow to opt out of the compatibility checks if really necessary.

Use `forceBuild` of the `OntologyLoaderOptions` to opt out:
```java
OntologyLoaderOptions options = OntologyLoaderOptions.builder()
  .forceBuild(true)
  .build();
```