### PR TITLE
Update dependencies

### DIFF
--- a/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/formats/mpo/MpAnnotationTest.java
+++ b/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/formats/mpo/MpAnnotationTest.java
@@ -1,7 +1,6 @@
 package org.monarchinitiative.phenol.annotations.formats.mpo;
 
 
-import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -15,7 +14,7 @@ public class MpAnnotationTest {
   @Test
   public void testAnnotationTypeString() {
     TermId mpId = TermId.of("MP:123");
-    Set<String> pmids = ImmutableSet.of();
+    Set<String> pmids = Set.of();
     MpAnnotation.Builder builder = new MpAnnotation.Builder(mpId,pmids).sexSpecific(MpSex.FEMALE);
     MpAnnotation annot = builder.build();
     String expected = "MP:123FEMALE_SPECIFIC_ABNORMAL";

--- a/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationFileParserTest.java
+++ b/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/hpo/HpoAnnotationFileParserTest.java
@@ -1,6 +1,5 @@
 package org.monarchinitiative.phenol.annotations.hpo;
 
-import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -84,14 +83,14 @@ class HpoAnnotationFileParserTest {
     }
     assertNotNull(anophthalmiaEntry);
     assertEquals(expectedFrequency,anophthalmiaEntry.getFrequencyModifier());
-    Set<String> expectedBiocuration= ImmutableSet.of("HP:probinson[2018-05-28]","HP:probinson[2019-05-28]");
+    Set<String> expectedBiocuration= Set.of("HP:probinson[2018-05-28]","HP:probinson[2019-05-28]");
     String actualBiocuration=anophthalmiaEntry.getBiocuration();
     String[] bioc=actualBiocuration.split(";");
     for (String biocurationItem : bioc) {
       assertTrue(expectedBiocuration.contains(biocurationItem));
     }
 
-    Set<String> expectedPublication=ImmutableSet.of("PMID:3214","PMID:1234");
+    Set<String> expectedPublication=Set.of("PMID:3214","PMID:1234");
     String actualPub=anophthalmiaEntry.getPublication();
     String []pubs=actualPub.split(";");
     for (String pub:pubs) {

--- a/phenol-io/pom.xml
+++ b/phenol-io/pom.xml
@@ -23,7 +23,6 @@
        <groupId>org.geneontology.obographs</groupId>
        <artifactId>obographs-core</artifactId>
     </dependency>
-    <!-- We can drop the dependency after obographs-core updates the vulnerable snakeyaml 1.33 to >=2.0. -->
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>

--- a/phenol-io/src/main/java/module-info.java
+++ b/phenol-io/src/main/java/module-info.java
@@ -10,6 +10,5 @@ module org.monarchinitiative.phenol.io {
   requires obographs.core;
   requires org.yaml.snakeyaml;
   requires com.fasterxml.jackson.databind;
-  requires com.fasterxml.jackson.datatype.guava;
   requires org.slf4j;
 }

--- a/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obographs/OboGraphDocumentLoader.java
+++ b/phenol-io/src/main/java/org/monarchinitiative/phenol/io/obographs/OboGraphDocumentLoader.java
@@ -1,7 +1,6 @@
 package org.monarchinitiative.phenol.io.obographs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import org.geneontology.obographs.core.model.GraphDocument;
 
 import java.io.IOException;
@@ -17,10 +16,6 @@ import java.nio.file.Path;
 public class OboGraphDocumentLoader {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-  static {
-    OBJECT_MAPPER.registerModule(new GuavaModule());
-  }
 
   private OboGraphDocumentLoader() {
   }

--- a/pom.xml
+++ b/pom.xml
@@ -19,15 +19,15 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
-    <obographs.version>0.3.0</obographs.version>
+    <obographs.version>0.3.1</obographs.version>
     <jackson.version>2.14.3</jackson.version>
-    <guava.version>30.1-jre</guava.version>
-    <snakeyaml.version>2.0</snakeyaml.version>
+    <guava.version>[32.0.1-jre,)</guava.version>
+    <snakeyaml.version>[2.0,3.0)</snakeyaml.version>
     <jgrapht.version>1.5.2</jgrapht.version>
-    <slf4j.version>2.0.7</slf4j.version>
+    <slf4j.version>[2.0,3.0)</slf4j.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-csv.version>1.10.0</commons-csv.version>
-    <h2.version>1.4.200</h2.version>
+    <h2.version>[2.2.220,3.0)</h2.version>
     <picocli.version>4.6.3</picocli.version>
 
     <hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
Update dependencies, most importantly `obographs-core`. Since Obographs does not use Guava anymore, the PR removes transitive Guava usage.

Fix #449