### PR TITLE
Add support for serialization of `GeneIdentifier`s

### DIFF
--- a/phenol-annotations/pom.xml
+++ b/phenol-annotations/pom.xml
@@ -19,11 +19,33 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.monarchinitiative.phenol</groupId>
       <artifactId>phenol-io</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
+ <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>--add-reads org.monarchinitiative.phenol.annotations=com.fasterxml.jackson.databind</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/phenol-annotations/src/main/java/module-info.java
+++ b/phenol-annotations/src/main/java/module-info.java
@@ -6,6 +6,7 @@ module org.monarchinitiative.phenol.annotations {
 
   requires java.xml;
   requires org.slf4j;
+  requires com.fasterxml.jackson.annotation;
 
     /*                                             Exports                                                              */
   exports org.monarchinitiative.phenol.annotations.analysis;

--- a/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/GeneIdentifier.java
+++ b/phenol-annotations/src/main/java/org/monarchinitiative/phenol/annotations/formats/GeneIdentifier.java
@@ -1,5 +1,6 @@
 package org.monarchinitiative.phenol.annotations.formats;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import org.monarchinitiative.phenol.ontology.data.Identified;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -22,6 +23,7 @@ public class GeneIdentifier implements Identified {
 
   /** A CURIE for the gene, such as NCBIGene:3949 */
   @Override
+  @JsonGetter
   public TermId id() {
     return id;
   }
@@ -29,6 +31,7 @@ public class GeneIdentifier implements Identified {
   /**
    * @return the symbol for the gene, e.g., LDLR
    */
+  @JsonGetter
   public String symbol() {
     return symbol;
   }

--- a/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/formats/GeneIdentifierTest.java
+++ b/phenol-annotations/src/test/java/org/monarchinitiative/phenol/annotations/formats/GeneIdentifierTest.java
@@ -1,0 +1,22 @@
+package org.monarchinitiative.phenol.annotations.formats;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class GeneIdentifierTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void serializeToJson() throws Exception {
+    GeneIdentifier gi = GeneIdentifier.of(TermId.of("NCBIGene:6834"), "SURF1");
+
+    String actual = objectMapper.writeValueAsString(gi);
+
+    assertThat(actual, equalTo("{\"id\":\"NCBIGene:6834\",\"symbol\":\"SURF1\"}"));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,11 @@
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>${jackson.version}</version>
       </dependency>


### PR DESCRIPTION
Use Jackson annotations to guide serialization of `GeneIdentifier`s into JSON, YAML, etc..