### PR TITLE
Augment `OntologyGraph` API

### DIFF
--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/graph/OntologyGraph.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/graph/OntologyGraph.java
@@ -536,6 +536,25 @@ public interface OntologyGraph<T> extends Iterable<T> {
   }
 
   /**
+   * Return {@code true} if the {@code left} and {@code right} nodes are sibling nodes, i.e. if they share at least
+   * one parent node and {@code false} otherwise.
+   * <p>
+   * Note, a term is not its own sibling.
+   */
+  default boolean nodesAreSiblings(T left, T right) {
+    if (left.equals(right))
+      return false;
+
+    for (T leftParent : getParents(left)) {
+      for (T rightParent : getParents(right)) {
+        if (leftParent.equals(rightParent))
+          return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Get the subgraph with {@code subRoot} as the new root node.
    */
   OntologyGraph<T> extractSubgraph(T subRoot);

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/graph/OntologyGraph.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/graph/OntologyGraph.java
@@ -65,8 +65,8 @@ public interface OntologyGraph<T> extends Iterable<T> {
    *                      or {@code false} otherwise.
    * @return the collection with the child nodes.
    */
-  default Collection<? super T> extendWithChildren(T source, boolean includeSource) {
-    Collection<? super T> collection = new ArrayList<>();
+  default Collection<T> extendWithChildren(T source, boolean includeSource) {
+    Collection<T> collection = new ArrayList<>();
     extendWithChildren(source, includeSource, collection);
     return collection;
   }
@@ -81,7 +81,7 @@ public interface OntologyGraph<T> extends Iterable<T> {
    */
   default void extendWithChildren(T source,
                                   boolean includeSource,
-                                  Collection<? super T> collection) {
+                                  Collection<T> collection) {
     if (includeSource)
       collection.add(source);
     collection.addAll(getChildren(source));
@@ -151,7 +151,7 @@ public interface OntologyGraph<T> extends Iterable<T> {
    *                      or {@code false} otherwise.
    * @return a collection with the descendant nodes.
    */
-  default Collection<? super T> extendWithDescendants(T source, boolean includeSource) {
+  default Collection<T> extendWithDescendants(T source, boolean includeSource) {
     return extendWithDescendants(source, includeSource, ArrayList::new);
   }
 
@@ -165,9 +165,9 @@ public interface OntologyGraph<T> extends Iterable<T> {
    * @param supplier      the collection supplier.
    * @param <C>           the desired collection type
    */
-  default <C extends Collection<? super T>> C extendWithDescendants(T source,
-                                                                    boolean includeSource,
-                                                                    Supplier<C> supplier) {
+  default <C extends Collection<T>> C extendWithDescendants(T source,
+                                                            boolean includeSource,
+                                                            Supplier<C> supplier) {
     C collection = supplier.get();
     extendWithDescendants(source, includeSource, collection);
     return collection;
@@ -183,7 +183,7 @@ public interface OntologyGraph<T> extends Iterable<T> {
    */
   default void extendWithDescendants(T source,
                                      boolean includeSource,
-                                     Collection<? super T> collection) {
+                                     Collection<T> collection) {
     if (includeSource)
       collection.add(source);
     getDescendants(source).forEach(collection::add);
@@ -199,7 +199,7 @@ public interface OntologyGraph<T> extends Iterable<T> {
    */
   default void extendMultipleWithDescendants(Iterable<T> sources,
                                              boolean includeSource,
-                                             Set<? super T> collection) {
+                                             Set<T> collection) {
     for (T source : sources)
       extendWithDescendants(source, includeSource, collection);
   }
@@ -286,8 +286,8 @@ public interface OntologyGraph<T> extends Iterable<T> {
    *                      or {@code false} otherwise.
    * @return the collection with the parent nodes.
    */
-  default Collection<? super T> extendWithParents(T source, boolean includeSource) {
-    Collection<? super T> collection = new ArrayList<>();
+  default Collection<T> extendWithParents(T source, boolean includeSource) {
+    Collection<T> collection = new ArrayList<>();
     extendWithParents(source, includeSource, collection);
     return collection;
   }
@@ -302,7 +302,7 @@ public interface OntologyGraph<T> extends Iterable<T> {
    */
   default void extendWithParents(T source,
                                  boolean includeSource,
-                                 Collection<? super T> collection) {
+                                 Collection<T> collection) {
     if (includeSource)
       collection.add(source);
     collection.addAll(getParents(source));
@@ -369,7 +369,7 @@ public interface OntologyGraph<T> extends Iterable<T> {
    *                      or {@code false} otherwise.
    * @return a collection with the ancestors nodes.
    */
-  default Collection<? super T> extendWithAncestors(T source, boolean includeSource) {
+  default Collection<T> extendWithAncestors(T source, boolean includeSource) {
     return extendWithAncestors(source, includeSource, ArrayList::new);
   }
 
@@ -383,9 +383,9 @@ public interface OntologyGraph<T> extends Iterable<T> {
    * @param supplier      the collection supplier.
    * @param <C>           the desired collection type
    */
-  default <C extends Collection<? super T>> C extendWithAncestors(T source,
-                                                                  boolean includeSource,
-                                                                  Supplier<C> supplier) {
+  default <C extends Collection<T>> C extendWithAncestors(T source,
+                                                          boolean includeSource,
+                                                          Supplier<C> supplier) {
     C ancestors = supplier.get();
     extendWithAncestors(source, includeSource, ancestors);
     return ancestors;
@@ -401,7 +401,7 @@ public interface OntologyGraph<T> extends Iterable<T> {
    */
   default void extendWithAncestors(T source,
                                    boolean includeSource,
-                                   Collection<? super T> collection) {
+                                   Collection<T> collection) {
     if (includeSource)
       collection.add(source);
     getAncestors(source).forEach(collection::add);
@@ -417,7 +417,7 @@ public interface OntologyGraph<T> extends Iterable<T> {
    */
   default void extendMultipleWithAncestors(Iterable<T> sources,
                                            boolean includeSource,
-                                           Set<? super T> collection) {
+                                           Set<T> collection) {
     for (T source : sources)
       extendWithAncestors(source, includeSource, collection);
   }

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/graph/OntologyGraph.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/graph/OntologyGraph.java
@@ -1,7 +1,9 @@
 package org.monarchinitiative.phenol.graph;
 
-import java.util.Spliterator;
+import java.util.*;
 import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -26,6 +28,15 @@ public interface OntologyGraph<T> extends Iterable<T> {
   T root();
 
   /**
+   * Get a {@linkplain Set} with <em>children</em> of the {@code source} node.
+   *
+   * @param source node whose children we are interested in.
+   * @return the set with child nodes.
+   * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   */
+  Set<T> getChildren(T source);
+
+  /**
    * Get an {@linkplain Iterable} over <em>children</em> of the {@code source} node.
    *
    * @param source        node whose children we are interested in.
@@ -33,8 +44,48 @@ public interface OntologyGraph<T> extends Iterable<T> {
    *                      or {@code false} otherwise.
    * @return an iterable as described above.
    * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   * @deprecated use {@link #getChildren(Object)} if you do not wish to see {@code source} in the iterable
+   * or {@link #extendWithChildren(Object, boolean)} if you need the {@code source} in the result.
    */
-  Iterable<T> getChildren(T source, boolean includeSource);
+  // REMOVE[3.0.0]
+  @Deprecated(forRemoval = true, since = "2.0.5")
+  default Iterable<T> getChildren(T source, boolean includeSource) {
+    Set<T> children = new HashSet<>();
+    extendWithChildren(source, includeSource, children);
+    return children;
+  }
+
+  /**
+   * Prepare a collection with <em>children</em> of the {@code source} node.
+   * <p>
+   * Note: consider using {@link #extendWithChildren(Object, boolean, Collection)} if you already have a collection.
+   *
+   * @param source        node whose children we are interested in.
+   * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
+   *                      or {@code false} otherwise.
+   * @return the collection with the child nodes.
+   */
+  default Collection<? super T> extendWithChildren(T source, boolean includeSource) {
+    Collection<? super T> collection = new ArrayList<>();
+    extendWithChildren(source, includeSource, collection);
+    return collection;
+  }
+
+  /**
+   * Extend an existing collection with <em>children</em> of the {@code source} node.
+   *
+   * @param source        node whose children we are interested in.
+   * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
+   *                      or {@code false} otherwise.
+   * @param collection    the existing collection.
+   */
+  default void extendWithChildren(T source,
+                                  boolean includeSource,
+                                  Collection<? super T> collection) {
+    if (includeSource)
+      collection.add(source);
+    collection.addAll(getChildren(source));
+  }
 
   /**
    * Get a {@linkplain Stream} over <em>children</em> of the {@code source} node.
@@ -44,10 +95,34 @@ public interface OntologyGraph<T> extends Iterable<T> {
    *                      or {@code false} otherwise.
    * @return a stream as described above.
    * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   * @deprecated use {@link #getChildrenStream(Object)} or {@link #extendWithChildren(Object, boolean)}
+   * instead.
    */
+  // REMOVE[3.0.0]
+  @Deprecated(forRemoval = true, since = "2.0.5")
   default Stream<T> getChildrenStream(T source, boolean includeSource) {
     return getSequentialStream(getChildren(source, includeSource).spliterator());
   }
+
+  /**
+   * Get a {@linkplain Stream} over <em>children</em> of the {@code source} node.
+   *
+   * @param source node whose children we are interested in.
+   * @return a stream.
+   * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   */
+  default Stream<T> getChildrenStream(T source) {
+    return getChildren(source).stream();
+  }
+
+  /**
+   * Get an {@linkplain Iterable} with <em>descendants</em> of the {@code source} node.
+   *
+   * @param source node whose descendants we are interested in.
+   * @return an iterable as described above.
+   * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   */
+  Iterable<T> getDescendants(T source);
 
   /**
    * Get an {@linkplain Iterable} over <em>descendants</em> of the {@code source} node.
@@ -57,8 +132,62 @@ public interface OntologyGraph<T> extends Iterable<T> {
    *                      or {@code false} otherwise.
    * @return an iterable as described above.
    * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   * @deprecated use {@link #getDescendants(Object)} if you do <em>not</em> want to include the source term in the iterator
+   * or {@link #extendWithDescendants(Object, boolean)} if you do.
    */
-  Iterable<T> getDescendants(T source, boolean includeSource);
+  // REMOVE[3.0.0]
+  @Deprecated(forRemoval = true, since = "2.0.5")
+  default Iterable<T> getDescendants(T source, boolean includeSource) {
+    Set<T> descendants = new HashSet<>();
+    extendWithDescendants(source, includeSource, descendants);
+    return descendants;
+  }
+
+  /**
+   * Get a collection with <em>descendants</em> of the {@code source} node.
+   *
+   * @param source        node whose descendants we are interested in.
+   * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
+   *                      or {@code false} otherwise.
+   * @return a collection with the descendant nodes.
+   */
+  default Collection<? super T> extendWithDescendants(T source, boolean includeSource) {
+    return extendWithDescendants(source, includeSource, ArrayList::new);
+  }
+
+  /**
+   * Extend a new instance of {@link C} obtained from the {@code supplier} with <em>descendants</em>
+   * of the {@code source} node.
+   *
+   * @param source        node whose descendants we are interested in.
+   * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
+   *                      or {@code false} otherwise.
+   * @param supplier      the existing collection.
+   * @param <C>           the desired collection type
+   */
+  default <C extends Collection<? super T>> C extendWithDescendants(T source,
+                                                                    boolean includeSource,
+                                                                    Supplier<C> supplier) {
+    C collection = supplier.get();
+    extendWithDescendants(source, includeSource, collection);
+    return collection;
+  }
+
+  /**
+   * Extend an existing collection with <em>descendants</em> of the {@code source} node.
+   *
+   * @param source        node whose descendants we are interested in.
+   * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
+   *                      or {@code false} otherwise.
+   * @param collection    the existing collection.
+   */
+  default void extendWithDescendants(T source,
+                                     boolean includeSource,
+                                     Collection<? super T> collection) {
+    if (includeSource)
+      collection.add(source);
+    getDescendants(source).forEach(collection::add);
+  }
 
   /**
    * Get a {@linkplain Stream} over <em>descendants</em> of the {@code source} node.
@@ -68,10 +197,50 @@ public interface OntologyGraph<T> extends Iterable<T> {
    *                      or {@code false} otherwise.
    * @return a stream as described above.
    * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   * @deprecated use {@link #getDescendantsStream(Object)} if you do not wish to see the {@code source} in the stream
+   * or {@link #extendWithDescendants(Object, boolean)} if you want to include the {@code source}.
+   * However, consider using {@link #extendWithDescendants(Object, boolean, Collection)} instead.
    */
+  // REMOVE[3.0.0]
+  @Deprecated(forRemoval = true, since = "2.0.5")
   default Stream<T> getDescendantsStream(T source, boolean includeSource) {
     return getSequentialStream(getDescendants(source, includeSource).spliterator());
   }
+
+  /**
+   * Get a {@linkplain Stream} over <em>descendants</em> of the {@code source} node.
+   *
+   * @param source node whose descendants we are interested in.
+   * @return a stream as described above.
+   * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   */
+  default Stream<T> getDescendantsStream(T source) {
+    return getSequentialStream(getDescendants(source).spliterator());
+  }
+
+  /**
+   * Get a {@linkplain Set} with <em>descendants</em> of the {@code source} node.
+   * <p>
+   * Note: consider using {@link #getDescendants(Object)} if all you need is to iterate
+   * or {@link #extendWithDescendants(Object, boolean, Collection)} if you wish to gather descendants
+   * of several ontology nodes.
+   *
+   * @param source node whose descendants we are interested in.
+   * @return a stream with descendants.
+   * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   */
+  default Set<T> getDescendantSet(T source) {
+    return getDescendantsStream(source).collect(Collectors.toSet());
+  }
+
+  /**
+   * Get an {@linkplain Iterable} over <em>parents</em> of the {@code source} node.
+   *
+   * @param source node whose parents we are interested in.
+   * @return an iterable as described above.
+   * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   */
+  Set<T> getParents(T source);
 
   /**
    * Get an {@linkplain Iterable} over <em>parents</em> of the {@code source} node.
@@ -81,8 +250,49 @@ public interface OntologyGraph<T> extends Iterable<T> {
    *                      or {@code false} otherwise.
    * @return an iterable as described above.
    * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   * @deprecated use {@link #getParents(Object)} if you do not wish to see {@code source} in the iterable
+   * or {@link #extendWithParents(Object, boolean)} if you need the {@code source} in the result.
    */
-  Iterable<T> getParents(T source, boolean includeSource);
+  // REMOVE[3.0.0]
+  @Deprecated(forRemoval = true, since = "2.0.5")
+  default Iterable<T> getParents(T source, boolean includeSource) {
+    Set<T> parents = new HashSet<>();
+    extendWithParents(source, includeSource, parents);
+    return parents;
+  }
+
+  /**
+   * Prepare a collection with <em>parents</em> of the {@code source} node.
+   * <p>
+   * Note: consider using {@link #extendWithParents(Object, boolean, Collection)} if you already have a collection.
+   *
+   * @param source        node whose parents we are interested in.
+   * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
+   *                      or {@code false} otherwise.
+   * @return the collection with the parent nodes.
+   */
+  default Collection<? super T> extendWithParents(T source, boolean includeSource) {
+    Collection<? super T> collection = new ArrayList<>();
+    extendWithParents(source, includeSource, collection);
+    return collection;
+  }
+
+  /**
+   * Extend an existing collection with <em>parents</em> of the {@code source} node.
+   *
+   * @param source        node whose parents we are interested in.
+   * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
+   *                      or {@code false} otherwise.
+   * @param collection        the existing collection.
+   */
+  default void extendWithParents(T source,
+                                 boolean includeSource,
+                                 Collection<? super T> collection) {
+    if (includeSource)
+      collection.add(source);
+    collection.addAll(getParents(source));
+  }
+
 
   /**
    * Get a {@linkplain Stream} over <em>parents</em> of the {@code source} node.
@@ -92,10 +302,34 @@ public interface OntologyGraph<T> extends Iterable<T> {
    *                      or {@code false} otherwise.
    * @return a stream as described above.
    * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   * @deprecated use {@link #getParentsStream(Object)} or {@link #extendWithParents(Object, boolean, Collection)}
+   * instead.
    */
+  // REMOVE[3.0.0]
+  @Deprecated(forRemoval = true, since = "2.0.5")
   default Stream<T> getParentsStream(T source, boolean includeSource) {
     return getSequentialStream(getParents(source, includeSource).spliterator());
   }
+
+  /**
+   * Get a {@linkplain Stream} over <em>parents</em> of the {@code source} node.
+   *
+   * @param source node whose parents we are interested in.
+   * @return a stream as described above.
+   * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   */
+  default Stream<T> getParentsStream(T source) {
+    return getParents(source).stream();
+  }
+
+  /**
+   * Get an {@linkplain Iterable} over <em>ancestors</em> of the {@code source} node.
+   *
+   * @param source node whose ancestors we are interested in.
+   * @return an iterable as described above.
+   * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   */
+  Iterable<T> getAncestors(T source);
 
   /**
    * Get an {@linkplain Iterable} over <em>ancestors</em> of the {@code source} node.
@@ -105,8 +339,58 @@ public interface OntologyGraph<T> extends Iterable<T> {
    *                      or {@code false} otherwise.
    * @return an iterable as described above.
    * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   * @deprecated use {@link #getAncestors(Object)} if you do not want to include the source term in the iterator or
+   * {@link #extendWithAncestors(Object, boolean, Collection)} if you do.
    */
+  // REMOVE[3.0.0]
+  @Deprecated(forRemoval = true, since = "2.0.5")
   Iterable<T> getAncestors(T source, boolean includeSource);
+
+  /**
+   * Get a collection with <em>ancestors</em> of the {@code source} node.
+   *
+   * @param source        node whose ancestors we are interested in.
+   * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
+   *                      or {@code false} otherwise.
+   * @return a collection with the ancestors nodes.
+   */
+  default Collection<? super T> extendWithAncestors(T source, boolean includeSource) {
+    return extendWithAncestors(source, includeSource, ArrayList::new);
+  }
+
+  /**
+   * Extend a new instance of {@link C} obtained from the {@code supplier} with <em>ancestors</em>
+   * of the {@code source} node.
+   *
+   * @param source        node whose ancestors we are interested in.
+   * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
+   *                      or {@code false} otherwise.
+   * @param supplier      the existing collection.
+   * @param <C>           the desired collection type
+   */
+  default <C extends Collection<? super T>> C extendWithAncestors(T source,
+                                                                  boolean includeSource,
+                                                                  Supplier<C> supplier) {
+    C ancestors = supplier.get();
+    extendWithAncestors(source, includeSource, ancestors);
+    return ancestors;
+  }
+
+  /**
+   * Extend an existing collection with <em>ancestors</em> of the {@code source} node.
+   *
+   * @param source        node whose ancestors we are interested in.
+   * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
+   *                      or {@code false} otherwise.
+   * @param collection        the existing collection.
+   */
+  default void extendWithAncestors(T source,
+                                   boolean includeSource,
+                                   Collection<? super T> collection) {
+    if (includeSource)
+      collection.add(source);
+    getAncestors(source).forEach(collection::add);
+  }
 
   /**
    * Get a {@linkplain Stream} over <em>ancestors</em> of the {@code source} node.
@@ -116,9 +400,40 @@ public interface OntologyGraph<T> extends Iterable<T> {
    *                      or {@code false} otherwise.
    * @return a stream as described above.
    * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   * @deprecated use {@link #getAncestorsStream(Object)} if you do not wish to see the {@code source} in the stream
+   * or {@link #extendWithAncestors(Object, boolean)} if you want to include the {@code source}.
+   * However, consider using {@link #extendWithAncestors(Object, boolean, Collection)} instead.
    */
+  // REMOVE[3.0.0]
+  @Deprecated(forRemoval = true, since = "2.0.5")
   default Stream<T> getAncestorsStream(T source, boolean includeSource) {
     return getSequentialStream(getAncestors(source, includeSource).spliterator());
+  }
+
+  /**
+   * Get a {@linkplain Stream} over <em>ancestors</em> of the {@code source} node.
+   *
+   * @param source node whose ancestors we are interested in.
+   * @return a stream as described above.
+   * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   */
+  default Stream<T> getAncestorsStream(T source) {
+    return getSequentialStream(getAncestors(source).spliterator());
+  }
+
+  /**
+   * Get a {@linkplain Set} with <em>ancestors</em> of the {@code source} node.
+   * <p>
+   * Note: consider using {@link #getAncestors(Object)} if all you need is to iterate
+   * or {@link #extendWithAncestors(Object, boolean, Collection)} if you wish to gather the ancestors
+   * of several ontology nodes.
+   *
+   * @param source node whose ancestors we are interested in.
+   * @return a stream with ancestors.
+   * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
+   */
+  default Set<T> getAncestorSet(T source) {
+    return getAncestorsStream(source).collect(Collectors.toSet());
   }
 
   /**
@@ -128,9 +443,10 @@ public interface OntologyGraph<T> extends Iterable<T> {
    * @throws NodeNotPresentInGraphException if the {@code source} is not a graph node.
    */
   default boolean isLeaf(T source) {
-    return !getChildren(source, false)
-      .iterator()
-      .hasNext();
+    for (T ignored : getChildren(source)) {
+      return false;
+    }
+    return true;
   }
 
   /**
@@ -156,7 +472,7 @@ public interface OntologyGraph<T> extends Iterable<T> {
    * @throws NodeNotPresentInGraphException if the {@code subject} or the {@code object} is not a graph node.
    */
   default boolean isParentOf(T subject, T object) {
-    return runQuery(t -> getParents(t, false), subject, object);
+    return runQuery(this::getParents, subject, object);
   }
 
   /**
@@ -166,7 +482,7 @@ public interface OntologyGraph<T> extends Iterable<T> {
    * @throws NodeNotPresentInGraphException if the {@code subject} or the {@code object} is not a graph node.
    */
   default boolean isAncestorOf(T subject, T object) {
-    return runQuery(t -> getAncestors(t, false), subject, object);
+    return runQuery(this::getAncestors, subject, object);
   }
 
   /**
@@ -176,7 +492,7 @@ public interface OntologyGraph<T> extends Iterable<T> {
    * @throws NodeNotPresentInGraphException if the {@code object} is not a graph node.
    */
   default boolean isChildOf(T subject, T object) {
-    return runQuery(t -> getChildren(t, false), subject, object);
+    return runQuery(this::getChildren, subject, object);
   }
 
   /**
@@ -186,7 +502,7 @@ public interface OntologyGraph<T> extends Iterable<T> {
    * @throws NodeNotPresentInGraphException if the {@code subject} or the {@code object} is not a graph node.
    */
   default boolean isDescendantOf(T subject, T object) {
-    return runQuery(t -> getDescendants(t, false), subject, object);
+    return runQuery(this::getDescendants, subject, object);
   }
 
   /**

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/graph/OntologyGraph.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/graph/OntologyGraph.java
@@ -72,12 +72,12 @@ public interface OntologyGraph<T> extends Iterable<T> {
   }
 
   /**
-   * Extend an existing collection with <em>children</em> of the {@code source} node.
+   * Extend a collection with <em>children</em> of the {@code source} node.
    *
    * @param source        node whose children we are interested in.
    * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
    *                      or {@code false} otherwise.
-   * @param collection    the existing collection.
+   * @param collection    the collection to extend.
    */
   default void extendWithChildren(T source,
                                   boolean includeSource,
@@ -156,13 +156,13 @@ public interface OntologyGraph<T> extends Iterable<T> {
   }
 
   /**
-   * Extend a new instance of {@link C} obtained from the {@code supplier} with <em>descendants</em>
+   * Extend an instance of {@link C} obtained from the {@code supplier} with <em>descendants</em>
    * of the {@code source} node.
    *
    * @param source        node whose descendants we are interested in.
    * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
    *                      or {@code false} otherwise.
-   * @param supplier      the existing collection.
+   * @param supplier      the collection supplier.
    * @param <C>           the desired collection type
    */
   default <C extends Collection<? super T>> C extendWithDescendants(T source,
@@ -174,12 +174,12 @@ public interface OntologyGraph<T> extends Iterable<T> {
   }
 
   /**
-   * Extend an existing collection with <em>descendants</em> of the {@code source} node.
+   * Extend a collection with <em>descendants</em> of the {@code source} node.
    *
    * @param source        node whose descendants we are interested in.
    * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
    *                      or {@code false} otherwise.
-   * @param collection    the existing collection.
+   * @param collection    the collection to extend.
    */
   default void extendWithDescendants(T source,
                                      boolean includeSource,
@@ -187,6 +187,21 @@ public interface OntologyGraph<T> extends Iterable<T> {
     if (includeSource)
       collection.add(source);
     getDescendants(source).forEach(collection::add);
+  }
+
+  /**
+   * Extend a collection with <em>descendants</em> of the {@code source} node.
+   *
+   * @param sources       an iterable of nodes whose descendants we are interested in.
+   * @param includeSource {@code true} if the {@code source} nodes should be included in the {@linkplain Set}
+   *                      or {@code false} otherwise.
+   * @param collection    the set to extend with the descendants.
+   */
+  default void extendMultipleWithDescendants(Iterable<T> sources,
+                                             boolean includeSource,
+                                             Set<? super T> collection) {
+    for (T source : sources)
+      extendWithDescendants(source, includeSource, collection);
   }
 
   /**
@@ -278,12 +293,12 @@ public interface OntologyGraph<T> extends Iterable<T> {
   }
 
   /**
-   * Extend an existing collection with <em>parents</em> of the {@code source} node.
+   * Extend a collection with <em>parents</em> of the {@code source} node.
    *
    * @param source        node whose parents we are interested in.
    * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
    *                      or {@code false} otherwise.
-   * @param collection        the existing collection.
+   * @param collection    the collection to extend.
    */
   default void extendWithParents(T source,
                                  boolean includeSource,
@@ -359,13 +374,13 @@ public interface OntologyGraph<T> extends Iterable<T> {
   }
 
   /**
-   * Extend a new instance of {@link C} obtained from the {@code supplier} with <em>ancestors</em>
+   * Extend an instance of {@link C} obtained from the {@code supplier} with <em>ancestors</em>
    * of the {@code source} node.
    *
    * @param source        node whose ancestors we are interested in.
    * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
    *                      or {@code false} otherwise.
-   * @param supplier      the existing collection.
+   * @param supplier      the collection supplier.
    * @param <C>           the desired collection type
    */
   default <C extends Collection<? super T>> C extendWithAncestors(T source,
@@ -377,12 +392,12 @@ public interface OntologyGraph<T> extends Iterable<T> {
   }
 
   /**
-   * Extend an existing collection with <em>ancestors</em> of the {@code source} node.
+   * Extend a collection with <em>ancestors</em> of the {@code source} node.
    *
    * @param source        node whose ancestors we are interested in.
    * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Collection}
    *                      or {@code false} otherwise.
-   * @param collection        the existing collection.
+   * @param collection    the collection to extend.
    */
   default void extendWithAncestors(T source,
                                    boolean includeSource,
@@ -390,6 +405,21 @@ public interface OntologyGraph<T> extends Iterable<T> {
     if (includeSource)
       collection.add(source);
     getAncestors(source).forEach(collection::add);
+  }
+
+  /**
+   * Extend a set with <em>ancestors</em> of the {@code source} node.
+   *
+   * @param sources       an iterable of nodes whose ancestors we are interested in.
+   * @param includeSource {@code true} if the {@code source} should be included in the {@linkplain Set}
+   *                      or {@code false} otherwise.
+   * @param collection    the set to extend with the ancestors.
+   */
+  default void extendMultipleWithAncestors(Iterable<T> sources,
+                                           boolean includeSource,
+                                           Set<? super T> collection) {
+    for (T source : sources)
+      extendWithAncestors(source, includeSource, collection);
   }
 
   /**

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/graph/csr/mono/CsrMonoOntologyGraph.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/graph/csr/mono/CsrMonoOntologyGraph.java
@@ -85,7 +85,7 @@ public class CsrMonoOntologyGraph<T> implements OntologyGraph<T> {
   @Override
   public void extendWithDescendants(T source,
                                     boolean includeSource,
-                                    Collection<? super T> collection) {
+                                    Collection<T> collection) {
     // TODO: a candidate for better implementation
     OntologyGraph.super.extendWithDescendants(source, includeSource, collection);
   }
@@ -122,7 +122,7 @@ public class CsrMonoOntologyGraph<T> implements OntologyGraph<T> {
   @Override
   public void extendWithAncestors(T source,
                                   boolean includeSource,
-                                  Collection<? super T> collection) {
+                                  Collection<T> collection) {
     // TODO: a candidate for better implementation
     OntologyGraph.super.extendWithAncestors(source, includeSource, collection);
   }

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/graph/csr/mono/CsrMonoOntologyGraph.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/graph/csr/mono/CsrMonoOntologyGraph.java
@@ -54,12 +54,28 @@ public class CsrMonoOntologyGraph<T> implements OntologyGraph<T> {
   }
 
   @Override
+  public Set<T> getChildren(T source) {
+    int index = getNodeIdx(source);
+    return children.getOutgoingNodes(index);
+  }
+
+  @Override
   public Iterable<T> getChildren(T source, boolean includeSource) {
+    // TODO - remove when the parent is removed
     return getImmediateNeighbors(children, source, includeSource);
   }
 
   @Override
+  public Iterable<T> getDescendants(T source) {
+    // Check if `source` is in the graph.
+    int intentionallyUnused = getNodeIdx(source);
+
+    return new IterableIteratorWrapper<>(() -> new TraversingIterator<>(source, this::getChildren));
+  }
+
+  @Override
   public Iterable<T> getDescendants(T source, boolean includeSource) {
+    // TODO - remove when the parent is removed
     // Check if `source` is in the graph.
     int intentionallyUnused = getNodeIdx(source);
 
@@ -67,16 +83,48 @@ public class CsrMonoOntologyGraph<T> implements OntologyGraph<T> {
   }
 
   @Override
+  public void extendWithDescendants(T source,
+                                    boolean includeSource,
+                                    Collection<? super T> collection) {
+    // TODO: a candidate for better implementation
+    OntologyGraph.super.extendWithDescendants(source, includeSource, collection);
+  }
+
+  @Override
+  public Set<T> getParents(T source) {
+    int index = getNodeIdx(source);
+    return parents.getOutgoingNodes(index);
+  }
+
+  @Override
   public Iterable<T> getParents(T source, boolean includeSource) {
+    // TODO - remove when the parent is removed
     return getImmediateNeighbors(parents, source, includeSource);
   }
 
   @Override
+  public Iterable<T> getAncestors(T source) {
+    // Check if `source` is in the graph.
+    int intentionallyUnused = getNodeIdx(source);
+
+    return new IterableIteratorWrapper<>(() -> new TraversingIterator<>(source, this::getParents));
+  }
+
+  @Override
   public Iterable<T> getAncestors(T source, boolean includeSource) {
+    // TODO - remove when the parent is removed
     // Check if `source` is in the graph.
     int intentionallyUnused = getNodeIdx(source);
 
     return new IterableIteratorWrapper<>(() -> new TraversingIterator<>(source, src -> getParents(src, includeSource)));
+  }
+
+  @Override
+  public void extendWithAncestors(T source,
+                                  boolean includeSource,
+                                  Collection<? super T> collection) {
+    // TODO: a candidate for better implementation
+    OntologyGraph.super.extendWithAncestors(source, includeSource, collection);
   }
 
   private Iterable<T> getImmediateNeighbors(StaticCsrArray<T> array,

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/graph/csr/poly/CsrPolyOntologyGraph.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/graph/csr/poly/CsrPolyOntologyGraph.java
@@ -58,6 +58,12 @@ public class CsrPolyOntologyGraph<T, E> implements OntologyGraph<T> {
     return root;
   }
 
+  @Override
+  public Set<T> getChildren(T source) {
+    // Not planned to use in production.
+    throw new PhenolRuntimeException("Not implemented");
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -66,6 +72,12 @@ public class CsrPolyOntologyGraph<T, E> implements OntologyGraph<T> {
     int idx = Util.getIndexOfUsingBinarySearch(source, nodes, comparator);
     Supplier<Iterator<Integer>> base = () -> getColsWithRelationship(idx, isChildOf, includeSource);
     return new IterableIteratorWrapper<>(() -> new InfallibleMappingIterator<>(base, this::getNodeForIndex));
+  }
+
+  @Override
+  public Iterable<T> getDescendants(T source) {
+    // Not planned to use in production.
+    throw new PhenolRuntimeException("Not implemented");
   }
 
   /**
@@ -78,6 +90,12 @@ public class CsrPolyOntologyGraph<T, E> implements OntologyGraph<T> {
     return new IterableIteratorWrapper<>(() -> new InfallibleMappingIterator<>(base, this::getNodeForIndex));
   }
 
+  @Override
+  public Set<T> getParents(T source) {
+    // Not planned to use in production.
+    throw new PhenolRuntimeException("Not implemented");
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -86,6 +104,12 @@ public class CsrPolyOntologyGraph<T, E> implements OntologyGraph<T> {
     int idx = Util.getIndexOfUsingBinarySearch(source, nodes, comparator);
     Supplier<Iterator<Integer>> base = () -> getColsWithRelationship(idx, isParentOf, includeSource);
     return new IterableIteratorWrapper<>(() -> new InfallibleMappingIterator<>(base, this::getNodeForIndex));
+  }
+
+  @Override
+  public Iterable<T> getAncestors(T source) {
+    // Not planned to use in production.
+    throw new PhenolRuntimeException("Not implemented");
   }
 
   /**

--- a/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/algo/OntologyAlgorithm.java
+++ b/phenol-core/src/main/java/org/monarchinitiative/phenol/ontology/algo/OntologyAlgorithm.java
@@ -224,21 +224,18 @@ public class OntologyAlgorithm {
   // Retrieve all ancestor terms from (sub)ontology where its new root node is rootTerm.
   // All nodes above that root node in the original ontology will be ignored.
   public static Set<TermId> getAncestorTerms(Ontology ontology, TermId rootTerm, Set<TermId> children, boolean includeOriginalTerm) {
-    // TODO - implement or deprecate
     Ontology subontology = ontology.subOntology(rootTerm);
     return getAncestorTerms(subontology, children, includeOriginalTerm);
   }
 
   public static Set<TermId> getAncestorTerms(Ontology ontology, TermId rootTerm, TermId child, boolean includeOriginalTerm) {
-    // TODO - implement or deprecate
     Ontology subontology = ontology.subOntology(rootTerm);
     return getAncestorTerms(subontology, child, includeOriginalTerm);
   }
 
   /**
    * @deprecated get {@link org.monarchinitiative.phenol.graph.OntologyGraph} by calling {@link MinimalOntology#graph()}
-   * and use {@link org.monarchinitiative.phenol.graph.OntologyGraph#getAncestorsStream(Object, boolean)} for each child,
-   * setting {@code includeSource=true}, and concatenate the streams.
+   * and use {@link org.monarchinitiative.phenol.graph.OntologyGraph#extendMultipleWithAncestors(Iterable, boolean, Set)}.
    * The method will be removed in <code>3.0.0</code>.
    */
   // REMOVE(3.0.0)
@@ -323,8 +320,7 @@ public class OntologyAlgorithm {
 
   /**
    * @deprecated get {@link org.monarchinitiative.phenol.graph.OntologyGraph} by calling {@link MinimalOntology#graph()}
-   * and use {@link org.monarchinitiative.phenol.graph.OntologyGraph#getParentsStream(Object, boolean)} for {@code t1}
-   * and {@code t2} and search for intersecting elements.
+   * and use {@link org.monarchinitiative.phenol.graph.OntologyGraph#nodesAreSiblings(Object, Object)}.
    * The method will be removed in <code>3.0.0</code>.
    */
   // REMOVE(3.0.0)

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/graph/OntologyGraphTest.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/graph/OntologyGraphTest.java
@@ -50,7 +50,7 @@ public abstract class OntologyGraphTest {
       "HP:03, ''",
     })
     public void getChildren(TermId source, String payload) {
-      Iterable<TermId> iterable = graph.getChildren(source, false);
+      Iterable<TermId> iterable = graph.getChildren(source);
       Set<TermId> expected = parsePayload(payload);
 
       iterableContainsTheExpectedItems(iterable, expected);
@@ -63,7 +63,7 @@ public abstract class OntologyGraphTest {
       "HP:03, HP:03",
     })
     public void getChildrenIncludingTheSource(TermId source, String payload) {
-      Iterable<TermId> iterable = graph.getChildren(source, true);
+      Collection<TermId> iterable = graph.extendWithChildren(source, true);
       Set<TermId> expected = parsePayload(payload);
 
       iterableContainsTheExpectedItems(iterable, expected);
@@ -71,7 +71,7 @@ public abstract class OntologyGraphTest {
 
     @Test
     public void getChildrenUnknownSource() {
-      NodeNotPresentInGraphException e = assertThrows(NodeNotPresentInGraphException.class, () -> graph.getChildren(UNKNOWN, false));
+      NodeNotPresentInGraphException e = assertThrows(NodeNotPresentInGraphException.class, () -> graph.getChildren(UNKNOWN));
       assertThat(e.getMessage(), equalTo("Item not found in the graph: HP:999"));
     }
 
@@ -158,7 +158,7 @@ public abstract class OntologyGraphTest {
       "HP:03,   ''",
     })
     public void getDescendants(TermId source, String payload) {
-      Iterable<TermId> iterable = graph.getDescendants(source, false);
+      Iterable<TermId> iterable = graph.getDescendants(source);
       Set<TermId> expected = parsePayload(payload);
 
       iterableContainsTheExpectedItems(iterable, expected);
@@ -179,7 +179,7 @@ public abstract class OntologyGraphTest {
       "HP:03,   HP:03",
     })
     public void getDescendantsIncludingTheSource(TermId source, String payload) {
-      Iterable<TermId> iterable = graph.getDescendants(source, true);
+      Iterable<TermId> iterable = graph.extendWithDescendants(source, true);
       Set<TermId> expected = parsePayload(payload);
 
       iterableContainsTheExpectedItems(iterable, expected);
@@ -187,7 +187,7 @@ public abstract class OntologyGraphTest {
 
     @Test
     public void getDescendantsUnknownSource() {
-      NodeNotPresentInGraphException e = assertThrows(NodeNotPresentInGraphException.class, () -> graph.getDescendants(UNKNOWN, false));
+      NodeNotPresentInGraphException e = assertThrows(NodeNotPresentInGraphException.class, () -> graph.getDescendants(UNKNOWN));
       assertThat(e.getMessage(), equalTo("Item not found in the graph: HP:999"));
     }
 
@@ -204,7 +204,7 @@ public abstract class OntologyGraphTest {
       "HP:0110, HP:010;HP:011",
     })
     public void getParents(TermId source, String payload) {
-      Iterable<TermId> iterable = graph.getParents(source, false);
+      Iterable<TermId> iterable = graph.getParents(source);
       Set<TermId> expected = parsePayload(payload);
 
       iterableContainsTheExpectedItems(iterable, expected);
@@ -218,7 +218,7 @@ public abstract class OntologyGraphTest {
       "HP:0110, HP:0110;HP:010;HP:011",
     })
     public void getParentsIncludingTheSource(TermId source, String payload) {
-      Iterable<TermId> iterable = graph.getParents(source, true);
+      Iterable<TermId> iterable = graph.extendWithParents(source, true);
       Set<TermId> expected = parsePayload(payload);
 
       iterableContainsTheExpectedItems(iterable, expected);
@@ -226,7 +226,7 @@ public abstract class OntologyGraphTest {
 
     @Test
     public void getParentsUnknownSource() {
-      NodeNotPresentInGraphException e = assertThrows(NodeNotPresentInGraphException.class, () -> graph.getParents(UNKNOWN, false));
+      NodeNotPresentInGraphException e = assertThrows(NodeNotPresentInGraphException.class, () -> graph.getParents(UNKNOWN));
       assertThat(e.getMessage(), equalTo("Item not found in the graph: HP:999"));
     }
 
@@ -279,7 +279,7 @@ public abstract class OntologyGraphTest {
       "HP:03,   HP:1",
     })
     public void getAncestors(TermId source, String payload) {
-      Iterable<TermId> iterable = graph.getAncestors(source, false);
+      Iterable<TermId> iterable = graph.getAncestors(source);
       Set<TermId> expected = parsePayload(payload);
 
       iterableContainsTheExpectedItems(iterable, expected);
@@ -294,7 +294,7 @@ public abstract class OntologyGraphTest {
       "HP:03,   HP:03;HP:1",
     })
     public void getAncestorsIncludingTheSource(TermId source, String payload) {
-      Iterable<TermId> iterable = graph.getAncestors(source, true);
+      Iterable<TermId> iterable = graph.extendWithAncestors(source, true);
       Set<TermId> expected = parsePayload(payload);
 
       iterableContainsTheExpectedItems(iterable, expected);
@@ -331,7 +331,7 @@ public abstract class OntologyGraphTest {
 
     @Test
     public void getAncestorsUnknownSource() {
-      NodeNotPresentInGraphException e = assertThrows(NodeNotPresentInGraphException.class, () -> graph.getAncestors(UNKNOWN, false));
+      NodeNotPresentInGraphException e = assertThrows(NodeNotPresentInGraphException.class, () -> graph.getAncestors(UNKNOWN));
       assertThat(e.getMessage(), equalTo("Item not found in the graph: HP:999"));
     }
 
@@ -476,7 +476,7 @@ public abstract class OntologyGraphTest {
     public void getParents(TermId root) {
       OntologyGraph<TermId> subgraph = graph.extractSubgraph(root);
 
-      assertThat(subgraph.getParents(root, false), is(emptyIterableOf(TermId.class)));
+      assertThat(subgraph.getParents(root), is(emptyIterableOf(TermId.class)));
     }
 
     @ParameterizedTest
@@ -497,7 +497,7 @@ public abstract class OntologyGraphTest {
     public void getAncestors(TermId root) {
       OntologyGraph<TermId> subgraph = graph.extractSubgraph(root);
 
-      assertThat(subgraph.getAncestors(root, false), is(emptyIterableOf(TermId.class)));
+      assertThat(subgraph.getAncestors(root), is(emptyIterableOf(TermId.class)));
     }
 
     @ParameterizedTest
@@ -519,7 +519,7 @@ public abstract class OntologyGraphTest {
       OntologyGraph<TermId> subgraph = graph.extractSubgraph(root);
 
       Set<TermId> expectedIds = parsePayload(expected);
-      iterableContainsTheExpectedItems(subgraph.getChildren(root, false), expectedIds);
+      iterableContainsTheExpectedItems(subgraph.getChildren(root), expectedIds);
     }
 
     @ParameterizedTest
@@ -541,7 +541,7 @@ public abstract class OntologyGraphTest {
       OntologyGraph<TermId> subgraph = graph.extractSubgraph(root);
 
       Set<TermId> expectedIds = parsePayload(expected);
-      iterableContainsTheExpectedItems(subgraph.getDescendants(root, false), expectedIds);
+      iterableContainsTheExpectedItems(subgraph.getDescendants(root), expectedIds);
     }
   }
 

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/graph/OntologyGraphTest.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/graph/OntologyGraphTest.java
@@ -385,6 +385,27 @@ public abstract class OntologyGraphTest {
       assertThat(e.getMessage(), equalTo("Item not found in the graph: HP:999"));
     }
 
+    @ParameterizedTest
+    @CsvSource({
+      "HP:01,  HP:02,  true",
+
+      "HP:020, HP:021, true",
+      "HP:021, HP:022, true",
+      "HP:022, HP:020, true",
+      "HP:03,  HP:01,  true",
+      "HP:03,  HP:02,  true",
+
+      // node is not its own sibling.
+      "HP:1,   HP:1,   false",
+      "HP:01,  HP:01,  false",
+
+      "HP:020, HP:02,  false",
+      "HP:020, HP:01,  false",
+      "HP:020, HP:010, false",
+    })
+    public void nodesAreSiblings(TermId left, TermId right, boolean expected) {
+      assertThat(graph.nodesAreSiblings(left, right), equalTo(expected));
+    }
   }
 
   /**

--- a/phenol-core/src/test/java/org/monarchinitiative/phenol/graph/csr/poly/CsrPolyOntologyGraphTest.java
+++ b/phenol-core/src/test/java/org/monarchinitiative/phenol/graph/csr/poly/CsrPolyOntologyGraphTest.java
@@ -1,5 +1,6 @@
 package org.monarchinitiative.phenol.graph.csr.poly;
 
+import org.junit.jupiter.api.Disabled;
 import org.monarchinitiative.phenol.graph.OntologyGraph;
 import org.monarchinitiative.phenol.graph.OntologyGraphEdges;
 import org.monarchinitiative.phenol.graph.OntologyGraphTest;
@@ -9,6 +10,7 @@ import org.monarchinitiative.phenol.ontology.data.TermId;
 /**
  * Check that we can use {@link CsrPolyOntologyGraph} as an {@link OntologyGraph}.
  */
+@Disabled("CsrPolyOntologyGraph is deprecated")
 public class CsrPolyOntologyGraphTest extends OntologyGraphTest {
 
 //  private static final byte C = 0b01; // child


### PR DESCRIPTION
The PR deprecates the `includeSource` flags on methods for getting children, parents, descendants and ancestors, and suggests the replacements. 

On top of that, the `OntologyGraph` API supports extending an existing collection with ancestors or descendant terms, and a few other convenience methods.